### PR TITLE
본사 재고 LOT 기준으로 수정, 지점 재고 페이지 완료 / 20250801

### DIFF
--- a/client/src/views/inventory/BranchStockPage.vue
+++ b/client/src/views/inventory/BranchStockPage.vue
@@ -16,8 +16,8 @@ const header = ref({
     compName: '지점명', 
     vendorName: '공급사', 
     productSpec: '규격', 
-    stockQuantity: '재고수량', 
-    safetyStock: '안전 재고', 
+    stockQuantity: '재고수량(개)', 
+    safetyStock: '안전 재고(개)', 
   },
   rightAligned: ['stockQuantity', 'safetyStock'] // 오른쪽 정렬할 컬럼 리스트
 });
@@ -289,11 +289,12 @@ const searchPublishers = async (searchValue) => {
 const searchStocks = async (searchOptions) => {
   try {
     console.log('Searching stocks with options:', searchOptions);
-    const response = await axios.get('/api/inventory/headStock/search', {
+    const response = await axios.get('/api/inventory/branchStock/search', {
       params: {
         productName: searchOptions.productModal || '',
-        categorySubName: searchOptions.productType || '',
+        categorySub: searchOptions.productType || '',
         vendorName: searchOptions.publisher || '',
+        compName: searchOptions.store || ''
       }
     });
     items.value = await response.data; // 서버에서 받은 데이터를 items에 저장

--- a/client/src/views/inventory/HeadStockPage.vue
+++ b/client/src/views/inventory/HeadStockPage.vue
@@ -1,4 +1,3 @@
-<!-- 조회 테스트 페이지 -->
 <script setup>
 import { onMounted, ref } from 'vue';
 import SearchTable from '../../components/common/SearchTable.vue';
@@ -11,12 +10,13 @@ const header = ref({
   header: { // 테이블의 헤더 정보
     productId: '제품번호', 
     productName: '제품명', 
+    lotNo: 'LOT',
     categoryMain: '대분류', 
     categorySub: '소분류', 
     vendorName: '공급사', 
     productSpec: '규격', 
-    stockQuantity: '재고수량', 
-    safetyStock: '안전 재고', 
+    stockQuantity: '재고수량(박스)', 
+    safetyStock: '안전 재고(박스)', 
   },
   rightAligned: ['stockQuantity', 'safetyStock'] // 오른쪽 정렬할 컬럼 리스트
 });
@@ -291,7 +291,7 @@ const searchStocks = async (searchOptions) => {
     const response = await axios.get('/api/inventory/headStock/search', {
       params: {
         productName: searchOptions.productModal || '',
-        categorySubName: searchOptions.productType || '',
+        categorySub: searchOptions.productType || '',
         vendorName: searchOptions.publisher || '',
       }
     });

--- a/server/src/main/java/com/olivin/app/config/SecurityConfig.java
+++ b/server/src/main/java/com/olivin/app/config/SecurityConfig.java
@@ -1,11 +1,8 @@
 // SecurityConfig.java
 package com.olivin.app.config;
 
-import com.olivin.app.auth.service.UserService;
-import com.olivin.app.security.JwtAuthenticationEntryPoint;
-import com.olivin.app.security.JwtAuthenticationFilter;
+import java.util.List;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -25,7 +22,11 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.List;
+import com.olivin.app.auth.service.UserService;
+import com.olivin.app.security.JwtAuthenticationEntryPoint;
+import com.olivin.app.security.JwtAuthenticationFilter;
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
@@ -62,7 +63,7 @@ public class SecurityConfig {
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 // 인증 없이 접근 가능한 경로
-                .requestMatchers("/api/auth/**").permitAll()
+                .requestMatchers("/api/auth/login").permitAll()
                 .requestMatchers("/api/outbndMgmt/**").permitAll()
                 .requestMatchers("/outbndMgmt/**").permitAll()
                 .requestMatchers("/api/inbndMgmt/**").permitAll()

--- a/server/src/main/java/com/olivin/app/inventory/service/HeadInventoryVO.java
+++ b/server/src/main/java/com/olivin/app/inventory/service/HeadInventoryVO.java
@@ -20,6 +20,7 @@ import lombok.NoArgsConstructor;
 public class HeadInventoryVO {
     private String productId; // 제품 ID
     private String productName; // 제품 이름
+    private String lotNo; // 로트 번호
     private String categoryMain; // 대분류
     private String categorySub; // 소분류
     private String vendorName; // 공급사 이름

--- a/server/src/main/resources/mapper/stock/branch-inventory-mapper.xml
+++ b/server/src/main/resources/mapper/stock/branch-inventory-mapper.xml
@@ -10,70 +10,97 @@
 <mapper namespace="com.olivin.app.inventory.mapper.BranchInventoryMapper">
     <!-- 지점 재고 전체 조회 -->
     <select id="selectAllBranchInventory" resultType="BranchInventoryVO">
-        SELECT p.product_id,
-            p.product_name,
-            get_datacode_name(p.category_main) as category_main,
-            get_datacode_name(p.category_sub) as category_sub,
-            p.vendor_name,
-            p.product_spec,
-            NVL((
-                SELECT SUM(inp.total_inbnd_quantity * prd.pack_qty)
-                FROM   inbnd_product inp JOIN inbnd ib ON ib.inbnd_no = inp.inbnd_no
-                                        JOIN products prd ON prd.product_id = inp.product_id
-                WHERE  ib.inbnd_to = 'COM10001'
-                AND  inp.inbnd_status = '000001'
-                AND  inp.product_id = p.product_id
-            ), 0) 
-            -
-            NVL((
-                SELECT SUM(outp.total_outbnd_quantity)
-                FROM   outbnd_product outp JOIN outbnd ob ON ob.outbnd_no = outp.outbnd_no
-                WHERE  ob.outbnd_from = 'COM10001'
-                AND  outp.outbnd_status = '010003'
-                AND  outp.product_id = p.product_id
-            ), 0) AS stock_quantity,
+        WITH branch_stocks AS (
+        SELECT   inp.product_id,
+                inp.product_name,
+                NVL(SUM(inp.total_inbnd_quantity) * prd.pack_qty, 0) as total_inbnd_quantity,
+                0 AS total_outbnd_quantity,
+                comp.comp_name
+        FROM     inbnd_product inp JOIN inbnd inb ON inb.inbnd_no = inp.inbnd_no
+                                    JOIN companys comp ON comp.comp_id = inb.inbnd_to
+                                    JOIN products prd ON prd.product_id = inp.product_id
+        WHERE    inb.outbnd_from = 'COM10001'
+            AND    inp.inbnd_status = '000001'
+        GROUP BY inp.product_id, inp.product_name, comp.comp_name, prd.pack_qty
 
-            p.safety_stock
-        FROM products p
+        UNION ALL
+
+        SELECT bod.product_id,
+                prd.product_name,
+                0 AS total_inbnd_quantity,
+                NVL(SUM(bod.outbnd_quantity), 0) AS total_outbnd_quantity,
+                comp.comp_name
+        FROM   br_outbnd_d bod JOIN products prd ON prd.product_id = bod.product_id
+                                JOIN br_outbnd br ON br.br_outbnd_no = bod.br_outbnd_no
+                                JOIN companys comp ON comp.comp_id = br.outbnd_from
+        GROUP BY bod.product_id, prd.product_name, comp.comp_name
+        )
+        SELECT   p.product_id,
+                 p.product_name,
+                 get_datacode_name(p.category_main) AS category_main,
+                 get_datacode_name(p.category_sub) AS category_sub,
+                 NVL(SUM(bs.total_inbnd_quantity), 0) - NVL(SUM(bs.total_outbnd_quantity), 0) AS stock_quantity,
+                 p.vendor_name,
+                 p.product_spec,
+                 bs.comp_name,
+                 p.safety_stock
+        FROM     products p JOIN branch_stocks bs ON p.product_id = bs.product_id
+        GROUP BY p.product_id, p.product_name, bs.comp_name, 
+                 p.category_main, p.category_sub, p.vendor_name, p.product_spec, p.safety_stock
         ORDER BY p.product_id
     </select>
     <!-- 조건에 맞는 지점 재고 조회 -->
     <select id="selectBranchInventoryList" parameterType="BranchInventoryVO" resultType="BranchInventoryVO">
-        SELECT p.product_id,
-            p.product_name,
-            get_datacode_name(p.category_main) as category_main,
-            get_datacode_name(p.category_sub) as category_sub,
-            p.vendor_name,
-            p.product_spec,
-            NVL((
-                SELECT SUM(inp.total_inbnd_quantity * prd.pack_qty)
-                FROM   inbnd_product inp JOIN inbnd ib ON ib.inbnd_no = inp.inbnd_no
-                                        JOIN products prd ON prd.product_id = inp.product_id
-                WHERE  ib.inbnd_to = 'COM10001'
-                AND  inp.inbnd_status = '000001'
-                AND  inp.product_id = p.product_id
-            ), 0) 
-            -
-            NVL((
-                SELECT SUM(outp.total_outbnd_quantity)
-                FROM   outbnd_product outp JOIN outbnd ob ON ob.outbnd_no = outp.outbnd_no
-                WHERE  ob.outbnd_from = 'COM10001'
-                AND  outp.outbnd_status = '010003'
-                AND  outp.product_id = p.product_id
-            ), 0) AS stock_quantity,
+        WITH branch_stocks AS (
+        SELECT   inp.product_id,
+                inp.product_name,
+                NVL(SUM(inp.total_inbnd_quantity) * prd.pack_qty, 0) as total_inbnd_quantity,
+                0 AS total_outbnd_quantity,
+                comp.comp_name
+        FROM     inbnd_product inp JOIN inbnd inb ON inb.inbnd_no = inp.inbnd_no
+                                    JOIN companys comp ON comp.comp_id = inb.inbnd_to
+                                    JOIN products prd ON prd.product_id = inp.product_id
+        WHERE    inb.outbnd_from = 'COM10001'
+            AND    inp.inbnd_status = '000001'
+        GROUP BY inp.product_id, inp.product_name, comp.comp_name, prd.pack_qty
 
-            p.safety_stock
-        FROM products p
-        WHERE 1=1
+        UNION ALL
+
+        SELECT bod.product_id,
+                prd.product_name,
+                0 AS total_inbnd_quantity,
+                NVL(SUM(bod.outbnd_quantity), 0) AS total_outbnd_quantity,
+                comp.comp_name
+        FROM   br_outbnd_d bod JOIN products prd ON prd.product_id = bod.product_id
+                                JOIN br_outbnd br ON br.br_outbnd_no = bod.br_outbnd_no
+                                JOIN companys comp ON comp.comp_id = br.outbnd_from
+        GROUP BY bod.product_id, prd.product_name, comp.comp_name
+        )
+        SELECT   p.product_id,
+                 p.product_name,
+                 get_datacode_name(p.category_main) AS category_main,
+                 get_datacode_name(p.category_sub) AS category_sub,
+                 NVL(SUM(bs.total_inbnd_quantity), 0) - NVL(SUM(bs.total_outbnd_quantity), 0) AS stock_quantity,
+                 p.vendor_name,
+                 p.product_spec,
+                 bs.comp_name,
+                 p.safety_stock
+        FROM     products p JOIN branch_stocks bs ON p.product_id = bs.product_id
+        WHERE    1=1
         <if test="productName != null and productName != ''">
-          AND p.product_name LIKE '%' || #{productName} || '%'
-        </if>
-        <if test="vendorName != null and vendorName != ''">
-          AND p.vendor_name LIKE '%' || #{vendorName} || '%'
+                AND p.product_name LIKE '%' || #{productName} || '%'
         </if>
         <if test="categorySub != null and categorySub != ''">
-          AND p.category_sub = #{categorySub}
+                AND get_datacode_name(p.category_sub) = #{categorySub}
         </if>
+        <if test="vendorName != null and vendorName != ''">
+                AND p.vendor_name LIKE '%' || #{vendorName} || '%'
+        </if>
+        <if test="compName != null and compName != ''">
+                AND bs.comp_name LIKE '%' || #{compName} || '%'
+        </if>
+        GROUP BY p.product_id, p.product_name, bs.comp_name, 
+                 p.category_main, p.category_sub, p.vendor_name, p.product_spec, p.safety_stock
         ORDER BY p.product_id
     </select>
 </mapper>

--- a/server/src/main/resources/mapper/stock/head-inventory-mapper.xml
+++ b/server/src/main/resources/mapper/stock/head-inventory-mapper.xml
@@ -6,74 +6,99 @@
 작성일 : 2025.07.30
 수정이력 :
 - 2025.07.30 : 최초 작성
+- 2025.08.01 : 재고 조회 LOT 단위로 출력하도록 수정
 -->
 <mapper namespace="com.olivin.app.inventory.mapper.HeadInventoryMapper">
     <!-- 본사 재고 전체 조회 -->
     <select id="selectAllHeadInventory" resultType="HeadInventoryVO">
+        WITH lot_stocks AS (
+            SELECT inp.product_id,
+                    ipd.lot_no,
+                    SUM(ipd.inbnd_quantity) AS inbnd_qty,
+                    0 AS outbnd_qty
+            FROM   inbnd_product_d ipd 
+                    JOIN inbnd inb ON inb.inbnd_no = SUBSTR(ipd.inbnd_d_no, 1, 13)
+                    JOIN inbnd_product inp ON inp.inbnd_product_no = ipd.inbnd_product_no
+            WHERE  ipd.inbnd_status = '000001'
+                AND  inb.inbnd_to = 'COM10001'
+            GROUP BY inp.product_id, ipd.lot_no
+            
+            UNION ALL
+            
+            SELECT outp.product_id,
+                    outpd.lot_no,
+                    0 AS inbnd_qty,
+                    SUM(outpd.outbnd_quantity) AS outbnd_qty
+            FROM   outbnd_product_d outpd 
+                    JOIN outbnd outb ON outb.outbnd_no = SUBSTR(outpd.outbnd_product_d_no, 1, 14)
+                    JOIN outbnd_product outp ON outp.outbnd_product_no = outpd.outbnd_product_no
+            WHERE  outpd.outbnd_status = '010003'
+                AND  outb.outbnd_from = 'COM10001'
+            GROUP BY outp.product_id, outpd.lot_no
+        )
         SELECT p.product_id,
-            p.product_name,
+            p.product_name || ' ' || p.pack_qty || '개입' as product_name,
+            ls.lot_no,
             get_datacode_name(p.category_main) as category_main,
             get_datacode_name(p.category_sub) as category_sub,
             p.vendor_name,
             p.product_spec,
-            NVL((
-                SELECT SUM(inp.total_inbnd_quantity * prd.pack_qty)
-                FROM   inbnd_product inp JOIN inbnd ib ON ib.inbnd_no = inp.inbnd_no
-                                        JOIN products prd ON prd.product_id = inp.product_id
-                WHERE  ib.inbnd_to = 'COM10001'
-                AND  inp.inbnd_status = '000001'
-                AND  inp.product_id = p.product_id
-            ), 0) 
-            -
-            NVL((
-                SELECT SUM(outp.total_outbnd_quantity)
-                FROM   outbnd_product outp JOIN outbnd ob ON ob.outbnd_no = outp.outbnd_no
-                WHERE  ob.outbnd_from = 'COM10001'
-                AND  outp.outbnd_status = '010003'
-                AND  outp.product_id = p.product_id
-            ), 0) AS stock_quantity,
-
-            p.safety_stock
-        FROM products p
+            NVL(SUM(ls.inbnd_qty) - SUM(ls.outbnd_qty), 0) AS stock_quantity,
+            p.safety_stock / p.pack_qty AS safety_stock -- 임시로 안전재고는 박스 포장단위로 나눠서 계산..
+        FROM   products p LEFT JOIN lot_stocks ls ON p.product_id = ls.product_id
+        GROUP BY p.product_id, p.product_name, ls.lot_no, p.category_main, p.category_sub, 
+                p.vendor_name, p.product_spec, p.pack_qty, p.safety_stock
         ORDER BY p.product_id
     </select>
     <!-- 조건에 맞는 본사 재고 조회 -->
     <select id="selectHeadInventoryList" parameterType="HeadInventoryVO" resultType="HeadInventoryVO">
+        WITH lot_stocks AS (
+            SELECT inp.product_id,
+                    ipd.lot_no,
+                    SUM(ipd.inbnd_quantity) AS inbnd_qty,
+                    0 AS outbnd_qty
+            FROM   inbnd_product_d ipd 
+                    JOIN inbnd inb ON inb.inbnd_no = SUBSTR(ipd.inbnd_d_no, 1, 13)
+                    JOIN inbnd_product inp ON inp.inbnd_product_no = ipd.inbnd_product_no
+            WHERE  ipd.inbnd_status = '000001'
+                AND  inb.inbnd_to = 'COM10001'
+            GROUP BY inp.product_id, ipd.lot_no
+            
+            UNION ALL
+            
+            SELECT outp.product_id,
+                    outpd.lot_no,
+                    0 AS inbnd_qty,
+                    SUM(outpd.outbnd_quantity) AS outbnd_qty
+            FROM   outbnd_product_d outpd 
+                    JOIN outbnd outb ON outb.outbnd_no = SUBSTR(outpd.outbnd_product_d_no, 1, 14)
+                    JOIN outbnd_product outp ON outp.outbnd_product_no = outpd.outbnd_product_no
+            WHERE  outpd.outbnd_status = '010003'
+                AND  outb.outbnd_from = 'COM10001'
+            GROUP BY outp.product_id, outpd.lot_no
+        )
         SELECT p.product_id,
-            p.product_name,
+            p.product_name || ' ' || p.pack_qty || ' 개입' as product_name,
+            ls.lot_no,
             get_datacode_name(p.category_main) as category_main,
             get_datacode_name(p.category_sub) as category_sub,
             p.vendor_name,
             p.product_spec,
-            NVL((
-                SELECT SUM(inp.total_inbnd_quantity * prd.pack_qty)
-                FROM   inbnd_product inp JOIN inbnd ib ON ib.inbnd_no = inp.inbnd_no
-                                        JOIN products prd ON prd.product_id = inp.product_id
-                WHERE  ib.inbnd_to = 'COM10001'
-                AND  inp.inbnd_status = '000001'
-                AND  inp.product_id = p.product_id
-            ), 0) 
-            -
-            NVL((
-                SELECT SUM(outp.total_outbnd_quantity)
-                FROM   outbnd_product outp JOIN outbnd ob ON ob.outbnd_no = outp.outbnd_no
-                WHERE  ob.outbnd_from = 'COM10001'
-                AND  outp.outbnd_status = '010003'
-                AND  outp.product_id = p.product_id
-            ), 0) AS stock_quantity,
-
-            p.safety_stock
-        FROM products p
-        WHERE 1=1
+            NVL(SUM(ls.inbnd_qty) - SUM(ls.outbnd_qty), 0) AS stock_quantity,
+            p.safety_stock / p.pack_qty AS safety_stock -- 임시로 안전재고는 박스 포장단위로 나눠서 계산..
+        FROM   products p LEFT JOIN lot_stocks ls ON p.product_id = ls.product_id
+        WHERE  1=1
         <if test="productName != null and productName != ''">
-          AND p.product_name LIKE '%' || #{productName} || '%'
-        </if>
-        <if test="vendorName != null and vendorName != ''">
-          AND p.vendor_name LIKE '%' || #{vendorName} || '%'
+            AND p.product_name LIKE '%' || #{productName} || '%'
         </if>
         <if test="categorySub != null and categorySub != ''">
-          AND p.category_sub = #{categorySub}
+            AND get_datacode_name(category_sub) = #{categorySub}
         </if>
+        <if test="vendorName != null and vendorName != ''">
+            AND p.vendor_name LIKE '%' || #{vendorName} || '%'
+        </if>
+        GROUP BY p.product_id, p.product_name, ls.lot_no, p.category_main, p.category_sub, 
+                p.vendor_name, p.product_spec, p.pack_qty, p.safety_stock
         ORDER BY p.product_id
     </select>
 </mapper>


### PR DESCRIPTION
This pull request introduces significant updates to the inventory management system, focusing on improving stock data accuracy and usability, as well as refining security configurations. Key changes include updates to the inventory views for branch and head stock, improvements to SQL queries for stock calculations, and security adjustments to restrict unauthorized access.

### Inventory View Updates:
* **Branch Stock Page (`BranchStockPage.vue`)**: Updated column headers to include unit labels (e.g., "재고수량(개)") and modified API parameters to align with backend changes (`categorySub` and `compName` fields). [[1]](diffhunk://#diff-3579567fd9bac68a29ecd551b611ae8515033a7bca15a424a6d698ca34e5e64cL19-R20) [[2]](diffhunk://#diff-3579567fd9bac68a29ecd551b611ae8515033a7bca15a424a6d698ca34e5e64cL292-R297)
* **Head Stock Page (`HeadStockPage.vue`)**: Added a new `lotNo` column for LOT-based inventory tracking and updated headers to include unit labels (e.g., "재고수량(박스)"). [[1]](diffhunk://#diff-42afaca5c03cffd11bcf1b4f662f453262c1843b8b95bce9a4cb94ecbae4f5acR13-R19) [[2]](diffhunk://#diff-42afaca5c03cffd11bcf1b4f662f453262c1843b8b95bce9a4cb94ecbae4f5acL294-R294)

### SQL Query Enhancements:
* **Branch Inventory Mapper (`branch-inventory-mapper.xml`)**: Replaced subqueries with a `WITH` clause for better performance and readability. Added support for filtering by `compName` and improved stock quantity calculations.
* **Head Inventory Mapper (`head-inventory-mapper.xml`)**: Introduced LOT-based stock tracking using a `WITH` clause, ensuring more granular inventory data. Updated safety stock calculations to reflect packaging units.

### Backend Model Updates:
* **`HeadInventoryVO`**: Added a new `lotNo` field to support LOT-based inventory tracking.

### Security Configuration Adjustments:
* **`SecurityConfig.java`**: Restricted public access to the `/api/auth/**` endpoint, allowing only `/api/auth/login` for unauthenticated users. Reorganized imports for clarity. [[1]](diffhunk://#diff-eef74926d9e24a2621a48e4930f1a0c371b974685fe71d3e0d0ffebfb516a5a7L4-L8) [[2]](diffhunk://#diff-eef74926d9e24a2621a48e4930f1a0c371b974685fe71d3e0d0ffebfb516a5a7L28-R29) [[3]](diffhunk://#diff-eef74926d9e24a2621a48e4930f1a0c371b974685fe71d3e0d0ffebfb516a5a7L65-R66)