### PR TITLE
판매 이력 조회 페이지 틀 구성 / 20250806

### DIFF
--- a/client/src/layout/AppMenu.vue
+++ b/client/src/layout/AppMenu.vue
@@ -57,7 +57,8 @@ const model = ref([
         to: '/sales',
         items: [
             { label: '매출 계획 조회', icon: 'pi pi-fw pi-book', to: '/sales/plan' },
-            { label: '주문 등록', icon: 'pi pi-fw pi-book', to: '/sales/orders' }
+            { label: '주문 등록', icon: 'pi pi-fw pi-book', to: '/sales/orders' },
+            { label: '판매 이력 조회', icon: 'pi pi-fw pi-book', to: '/sales/history' },
         ]
     },
     {   

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -260,6 +260,11 @@ const router = createRouter({
                     component: () => import('@/views/sales/SalesOrdersPage.vue'),
                     meta: { roles: ['ROLE_STORE_MANAGER'] }
                 },
+                {
+                    path: '/sales/history',
+                    name: 'salesHistory',
+                    component: () => import('@/views/sales/SalesHistoryPage.vue'),
+                }
                 /* end of sales */
             ]
         },

--- a/client/src/views/sales/SalesHistoryPage.vue
+++ b/client/src/views/sales/SalesHistoryPage.vue
@@ -1,0 +1,355 @@
+<script setup>
+import { onMounted, ref } from 'vue';
+import SearchTable from '../../components/common/SearchTable.vue';
+import axios from '@/service/axios';
+import DialogModal from '@/components/overray/DialogModal.vue';
+
+// 조회 폼의 헤더 정보 (조회 테이블 컬럼 이름)
+const header = ref({
+  title: '판매 이력 검색', // 조회 폼 제목
+  header: { // 테이블의 헤더 정보
+    productId: '제품번호', 
+    productName: '제품명', 
+    lotNo: 'LOT',
+    categoryMain: '대분류', 
+    categorySub: '소분류', 
+    vendorName: '공급사', 
+    productSpec: '규격', 
+    stockQuantity: '재고수량(박스)', 
+    safetyStock: '안전 재고(박스)', 
+  },
+  rightAligned: ['stockQuantity', 'safetyStock'] // 오른쪽 정렬할 컬럼 리스트
+});
+
+// 조회할 데이터
+const items = ref([]);
+
+// 검색 조건 필터 설정
+const filters = ref({});
+filters.value.title = '재고 검색'; // 검색 조건 폼 제목
+filters.value.filters = [ // 검색 조건 필터 목록
+  { type: 'item-search', label: '매출번호', value: '', placeholder: '매출 검색', name: 'salesSearchModal' },
+  { type: 'dateRange', label: '매출일자', value: '', fromPlaceholder: '', name: 'salesDates' },
+  { type: 'select', label: '매출상태', value: '', placeholder: '공급사 검색', name: 'publisher' },
+  // { type: 'item-search', label: '지점', value: '', placeholder: '지점명 검색', name: 'store' },
+];
+
+/*
+ * 모달창 관련 설정
+ * 모달창의 visible 상태를 관리하는 ref 변수
+ * 모달창의 헤더 정보와 아이템 목록을 관리하는 ref 변수
+ */
+
+// 모달창의 테이블 헤더 정보
+// field: 테이블의 각 컬럼에 해당하는 데이터의 키
+// header: 테이블의 각 컬럼에 해당하는 헤더 이름
+
+// 제품 모달창 헤더
+const productHeaders = ref([
+  { field: 'productId', header: '제품번호' },
+  { field: 'productName', header: '제품명' },
+  { field: 'categoryMain', header: '대분류' },
+  { field: 'categorySub', header: '소분류' },
+  { field: 'vendorName', header: '공급사' },
+  { field: 'productSpec', header: '규격' },
+]);
+
+// 모달창의 데이터 아이템
+// 제품 모달창 아이템
+const productItems = ref([]);
+
+// =====
+// 여러개의 모달창이 필요할 경우 여러개를 각각 정의
+const typeHeaders = ref([
+  { field: 'categoryMainName', header: '대분류' },
+  { field: 'categorySubName', header: '소분류' },
+]);
+
+const typeItems = ref([]);
+
+const salesHeaders = ref([
+  { field: 'vendorName', header: '업체명' },
+  { field: 'phone', header: '전화번호' },
+]);
+
+const salesItems = ref([]);
+
+const storeHeaders = ref([
+  { field: 'compId', header: 'ID' },
+  { field: 'compName', header: '회사명' },
+  { field: 'ceoName', header: '대표자' },
+  { field: 'phone', header: '전화번호' },
+]);
+
+const storeItems = ref([]);
+
+// 필터 설정
+const setFilters = async () => {
+  try {
+    const response = await axios.get('/api/search/sales/status');
+    const salesStatuses = await response.data;
+
+    filters.value.title = '매출 검색'; // 검색 조건 폼 제목
+    filters.value.filters = [
+      { type: 'item-search', label: '매출번호', value: '', placeholder: '매출 검색', name: 'salesSearchModal' },
+      { type: 'dateRange', label: '매출일자', value: '', fromPlaceholder: '', name: 'salesDates' },
+      { type: 'select', label: '매출상태', value: '', placeholder: '공급사 검색', name: 'salesStatus', options: [
+        ...salesStatuses.map(status => ({ name: status.name, value: status.name }))
+      ] },
+      { type: 'item-search', label: '제품명', value: '', placeholder: '제품 검색', name: 'products' },
+      { type: 'item-search', label: '제품분류', value: '', placeholder: '제품분류 검색', name: 'productType' },
+      { type: 'item-search', label: '지점명', value: '', placeholder: '지점명 검색', name: 'store' },
+    ];
+  } catch (error) {
+    console.error('Error setting filters:', error);
+  }
+}
+
+// =====
+
+// 검색 모달이 필요할 때 선언해서 사용.
+// 모달의 visible 상태를 관리하는 ref 변수
+const productModalVisible = ref(false);
+const typeModalVisible = ref(false);
+const salesModalVisible = ref(false);
+const storeModalVisible = ref(false);
+
+const loadProductItems = async () => {
+  try {
+    // 제품 목록을 서버에서 가져오기
+    const response = await axios.get('/api/search/products/all');
+    productItems.value = await response.data; // 서버에서 받은 데이터를 productItems에 저장
+
+    console.log('Product items loaded:', productItems.value);
+    
+  } catch (error) {
+    console.error('Error loading product items:', error);
+  }
+};
+
+const loadTypeItems = async () => {
+  try {
+    // 제품 분류 목록을 서버에서 가져오기
+    const response = await axios.get('/api/search/product-types/all');
+    typeItems.value = await response.data; // 서버에서 받은 데이터를 typeItems에 저장
+
+    console.log('Product type items loaded:', typeItems.value);
+
+  } catch (error) {
+    console.error('Error loading product type items:', error);
+  }
+};
+
+const loadStoreItems = async () => {
+  try {
+    // 지점 목록을 서버에서 가져오기
+    const response = await axios.get('/api/search/branches/all');
+    storeItems.value = await response.data; // 서버에서 받은 데이터를 storeItems에 저장
+
+    console.log('Store items loaded:', storeItems.value);
+
+  } catch (error) {
+    console.error('Error loading store items:', error);
+  }
+};
+
+const loadSalesItems = async () => {
+  try {
+    // 매출 목록을 서버에서 가져오기
+    const response = await axios.get('/api/search/sales/all');
+    salesItems.value = await response.data; // 서버에서 받은 데이터를 salesItems에 저장
+
+    console.log('Sales items loaded:', salesItems.value);
+
+  } catch (error) {
+    console.error('Error loading sales items:', error);
+  }
+};
+
+// 검색 폼에서 검색 버튼 클릭 시 호출되는 함수
+const searchData = async (searchOptions) => {
+  console.log('Searching with options:', searchOptions);
+  await searchStocks(searchOptions);
+  
+};
+
+// 검색 모달을 열 때 호출되는 함수
+// case 문을 사용하여 모달 이름(item-search 타입의 name을 따름)에 따라 다른 모달을 열 수 있도록 구현
+const handleOpenModal = (filterName) => {
+  console.log('Open modal for filter:', filterName);
+  switch (filterName) {
+    case 'productModal':
+      loadProductItems();
+      productModalVisible.value = true;
+      break;
+    case 'productType':
+      loadTypeItems();
+      typeModalVisible.value = true;
+      break;
+    case 'salesSearchModal':
+      loadSalesItems();
+      salesModalVisible.value = true;
+      break;
+    case 'store':
+      loadStoreItems();
+      storeModalVisible.value = true;
+      break;
+    default:
+      console.warn('No modal defined for filter:', filterName);
+  }
+};
+
+/*************************
+ * 모달창 닫기 함수 영역 *
+ *************************/
+const closeProductModal = () => {
+  productModalVisible.value = false;
+}
+const closeTypeModal = () => {
+  typeModalVisible.value = false;
+}
+const closeSalesModal = () => {
+  salesModalVisible.value = false;
+}
+const closeStoreModal = () => {
+  storeModalVisible.value = false;
+}
+
+/******************************
+ * 모달창 확인 버튼 함수 영역 *
+ ******************************/
+
+// SearchForm의 ref를 추가
+const searchFormRef = ref(null);
+
+const updateFilterValue = (filterName, selectedItem) => {
+  // SearchForm의 searchOptions에 직접 값 설정
+  if (searchFormRef.value.searchFormRef.searchOptions) {
+    searchFormRef.value.searchFormRef.searchOptions[filterName] = selectedItem;
+  }
+};
+
+// 제품 선택 모달 선택 버튼
+const confirmProductModal = (selectedItems) => {
+  console.log('Selected items from product modal:', selectedItems);
+  if (selectedItems) {
+    updateFilterValue('productModal', selectedItems.productName);
+  }
+  productModalVisible.value = false;
+};
+
+// 제품 분류 선택 모달 선택 버튼
+const confirmTypeModal = (selectedItems) => {
+  console.log('Selected items from type modal:', selectedItems);
+  if (selectedItems) {
+    updateFilterValue('productType', selectedItems.categorySubName);
+  }
+  typeModalVisible.value = false;
+};
+
+// 지점 선택 모달 선택 버튼
+const confirmStoreModal = (selectedItems) => {
+  console.log('Selected items from store modal:', selectedItems);
+  if (selectedItems) {
+    updateFilterValue('store', selectedItems);
+  }
+  storeModalVisible.value = false;
+};
+
+// 매출 검색 모달 선택 버튼
+const confirmSalesModal = (selectedItems) => {
+  console.log('Selected items from sales modal:', selectedItems);
+  if (selectedItems) {
+    updateFilterValue('salesSearchModal', selectedItems.salesId);
+  }
+  salesModalVisible.value = false;
+};
+
+/****************************
+ * 모달 내부 검색 함수 영역 *
+ ****************************/
+
+// 제품 모달 내부 검색 함수
+const searchProducts = async (searchValue) => {
+  try {
+    console.log('Searching products with value:', searchValue);
+    const response = await axios.get('/api/search/products', {
+      params: {
+        searchValue: searchValue
+      }
+    });
+    productItems.value = await response.data; // 서버에서 받은 데이터를 items에 저장
+  } catch (error) {
+    console.error('Error searching products:', error);
+  }
+};
+
+// 제품 분류 모달 내부 검색 함수
+const searchProductTypes = async (searchValue) => {
+  try {
+    console.log('Searching product types with value:', searchValue);
+    const response = await axios.get('/api/search/product-types', {
+      params: {
+        searchValue: searchValue
+      }
+    });
+    typeItems.value = await response.data; // 서버에서 받은 데이터를 items에 저장
+  } catch (error) {
+    console.error('Error searching product types:', error);
+  }
+};
+
+// 매출 모달 내부 검색 함수
+const searchSales = async (searchValue) => {
+  try {
+    console.log('Searching sales with value:', searchValue);
+    const response = await axios.get('/api/search/sales', {
+      params: {
+        searchValue: searchValue
+      }
+    });
+    salesItems.value = await response.data; // 서버에서 받은 데이터를 items에 저장
+  } catch (error) {
+    console.error('Error searching sales:', error);
+  }
+};
+
+// 조회 버튼 클릭했을 때 실제 실행되는 함수
+const searchStocks = async (searchOptions) => {
+  try {
+    console.log('Searching stocks with options:', searchOptions);
+    const response = await axios.get('/api/inventory/headStock/search', {
+      params: {
+        productName: searchOptions.productModal || '',
+        categorySub: searchOptions.productType || '',
+        vendorName: searchOptions.publisher || '',
+      }
+    });
+    items.value = await response.data; // 서버에서 받은 데이터를 items에 저장
+    console.log('Stocks searched:', items.value);
+  } catch (error) {
+    console.error('Error searching stocks:', error);
+  }
+};
+
+const resetList = () => {
+  loadStockData();
+}
+
+onMounted(() => {
+  setFilters();
+  loadStockData();
+});
+
+</script>
+<template>
+  <SearchTable ref="searchFormRef" :filters="filters" :items="items" :header="header" @searchData="searchData" @open-search-modal="handleOpenModal" @resetSearchOptions="resetList"></SearchTable>
+  <DialogModal v-model:display="productModalVisible" :items="productItems" :headers="productHeaders" title="제품 검색"
+    selectionMode="single" @close="closeProductModal" @confirm="confirmProductModal" @search-modal="searchProducts" />
+  <DialogModal v-model:display="typeModalVisible" :items="typeItems" :headers="typeHeaders" title="제품 분류 검색"
+    selectionMode="single" @close="closeTypeModal" @confirm="confirmTypeModal" @search-modal="searchProductTypes" />
+  <DialogModal v-model:display="salesModalVisible" :items="salesItems" :headers="salesHeaders" title="매출 검색"
+    selectionMode="single" @close="closeSalesModal" @confirm="confirmSalesModal" @search-modal="searchSales"/>
+  <DialogModal v-model:display="storeModalVisible" :items="storeItems" :headers="storeHeaders" title="지점 검색"
+    selectionMode="single" @close="closeStoreModal" @confirm="confirmStoreModal" />
+</template>

--- a/server/src/main/java/com/olivin/app/sales/mapper/SalesHistoryMapper.java
+++ b/server/src/main/java/com/olivin/app/sales/mapper/SalesHistoryMapper.java
@@ -1,0 +1,18 @@
+package com.olivin.app.sales.mapper;
+
+import java.util.List;
+
+import com.olivin.app.sales.service.SalesHistoryVO;
+
+/**
+ * SalesHistoryMapper 인터페이스 <br>
+ * 판매 이력 관련 데이터베이스 작업을 위한 매퍼 인터페이스입니다.
+ * 
+ * 작성자: 함동의
+ * 작성일: 2025.08.06
+ * 수정이력:
+ * - 2025.08.06 : 최초 작성
+ */
+public interface SalesHistoryMapper {
+    List<SalesHistoryVO> selectHistoryAll();
+}

--- a/server/src/main/java/com/olivin/app/sales/service/SalesHistoryService.java
+++ b/server/src/main/java/com/olivin/app/sales/service/SalesHistoryService.java
@@ -1,0 +1,19 @@
+package com.olivin.app.sales.service;
+
+import java.util.List;
+
+/**
+ * SalesHistoryService 인터페이스 <br>
+ * 판매 이력 관련 서비스 인터페이스입니다.
+ * 
+ * 작성자: 함동의
+ * 작성일: 2025.08.06
+ * 수정이력:
+ * - 2025.08.06 : 최초 작성
+ */
+public interface SalesHistoryService {
+    /**
+     * 판매 이력 전체 조회
+     */
+    List<SalesHistoryVO> getHistoryAll();
+}

--- a/server/src/main/java/com/olivin/app/sales/service/SalesHistoryVO.java
+++ b/server/src/main/java/com/olivin/app/sales/service/SalesHistoryVO.java
@@ -1,0 +1,20 @@
+package com.olivin.app.sales.service;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SalesHistoryVO {
+    private String productId;
+    private String productName;
+    private String categoryMain;
+    private String categorySub;
+    private String compName;
+    private String vendorName;
+    private String productSpec;
+    private int stockQuantity;
+    private int safetyStock;
+}

--- a/server/src/main/java/com/olivin/app/sales/service/impl/SalesHistoryServiceImpl.java
+++ b/server/src/main/java/com/olivin/app/sales/service/impl/SalesHistoryServiceImpl.java
@@ -1,0 +1,23 @@
+package com.olivin.app.sales.service.impl;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.olivin.app.sales.mapper.SalesHistoryMapper;
+import com.olivin.app.sales.service.SalesHistoryService;
+import com.olivin.app.sales.service.SalesHistoryVO;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SalesHistoryServiceImpl implements SalesHistoryService {
+    private final SalesHistoryMapper salesHistoryMapper;
+
+    @Override
+    public List<SalesHistoryVO> getHistoryAll() {
+        return salesHistoryMapper.selectHistoryAll();
+    }
+
+}


### PR DESCRIPTION
This pull request introduces a new "판매 이력 조회" (Sales History Lookup) feature to the sales module, covering both frontend and backend changes. The main additions include a new page and menu entry for viewing sales history, along with the supporting backend service, mapper, and value object to retrieve sales history data.

**Frontend changes: Sales history page and navigation**

* Added a new menu item "판매 이력 조회" to the sales section in `AppMenu.vue` so users can navigate to the sales history page.
* Registered a new route `/sales/history` in the router, pointing to the new `SalesHistoryPage.vue` component.
* Implemented the `SalesHistoryPage.vue` component, which provides a searchable table for sales history, modal dialogs for filtering/searching by product, type, sales, and store, and integrates with backend APIs to fetch relevant data.

**Backend changes: Sales history retrieval**

* Created the `SalesHistoryVO` value object to represent sales history records, including fields such as product, category, vendor, and stock information.
* Added the `SalesHistoryMapper` interface for database access, with a method to select all sales history records.
* Defined the `SalesHistoryService` interface and its implementation `SalesHistoryServiceImpl`, which delegates to the mapper to retrieve all sales history data. [[1]](diffhunk://#diff-1cfedacc176c591be7bf5e11fcfc387f52a95b318442250601d328114961f893R1-R19) [[2]](diffhunk://#diff-44630f76001005bed996582afb827b401aa02815cad0fa5c4d4536c2a5a2f62cR1-R23)