### PR TITLE
UI/UX 개선 및 일일 정산 추가 / 20250809

### DIFF
--- a/client/src/components/inputForm/DatePickerFromTo.vue
+++ b/client/src/components/inputForm/DatePickerFromTo.vue
@@ -13,6 +13,10 @@ const props = defineProps({
   toPlaceholder: {
     type: String,
     default: ''
+  },
+  disabled: {
+    type: Boolean,
+    default: false
   }
 });
 
@@ -34,9 +38,9 @@ watch(() => toValue.value, (newValue) => {
 
 </script>
 <template>
-<DatePicker :showIcon="true" :showButtonBar="true" v-model="fromValue" dateFormat="yy-mm-dd" :placeholder="props.fromPlaceholder" class="flex-1"></DatePicker>
+<DatePicker :showIcon="true" :showButtonBar="true" v-model="fromValue" dateFormat="yy-mm-dd" :placeholder="props.fromPlaceholder" :disabled="props.disabled" class="flex-1"></DatePicker>
 <span> ~ </span>
-<DatePicker :showIcon="true" :showButtonBar="true" v-model="toValue" dateFormat="yy-mm-dd" :placeholder="props.toPlaceholder" class="flex-1"></DatePicker>
+<DatePicker :showIcon="true" :showButtonBar="true" v-model="toValue" dateFormat="yy-mm-dd" :placeholder="props.toPlaceholder" :disabled="props.disabled" class="flex-1"></DatePicker>
 </template>
 <style>
 

--- a/client/src/components/inputForm/InputForm.vue
+++ b/client/src/components/inputForm/InputForm.vue
@@ -137,7 +137,7 @@ defineExpose({
       <div v-for="(input, index) in inputs.inputs" :key="input.name || index" class="grid grid-cols-12 gap-2"
         :class="(input.type === 'dateRange' || input.type === 'textarea' || input.type === 'file') ? 'col-span-2' : 'col-span-1'">
 
-        <label :for="input.label" class="flex items-center col-span-12 mb-2 md:col-span-3 md:mb-0">{{ input.label
+        <label :for="input.label" class="flex items-center col-span-12 mb-2 md:col-span-3 md:mb-0 text-lg font-medium">{{ input.label
           }}</label>
         <div v-if="input.type !== 'textarea' && input.type !== 'file'" class="col-span-12 md:col-span-9 flex">
 

--- a/client/src/components/inputForm/InputMaster.vue
+++ b/client/src/components/inputForm/InputMaster.vue
@@ -34,7 +34,7 @@ const searchItem = (item, fieldName) => {
       <div class="grid grid-cols-2 gap-6">
         <div v-for="(element, idx) in formSchema" :key="idx" class="flex flex-col gap-4">
           <div class="grid grid-cols-12 gap-2">
-            <label :for="'form-' + element.id" class="flex items-center justify-center col-span-12 mb-2 sm:col-span-3 sm:mb-0">{{ element.label }}</label>
+            <label :for="'form-' + element.id" class="flex items-center justify-center col-span-12 mb-2 sm:col-span-3 sm:mb-0 text-lg font-medium">{{ element.label }}</label>
             <div class="col-span-12 sm:col-span-9">
               <!-- 입력 : text, combobox, number(float), data, searchInput(공급) -->
               

--- a/client/src/components/inputForm/SearchForm.vue
+++ b/client/src/components/inputForm/SearchForm.vue
@@ -25,11 +25,11 @@ const initializeSearchOptions = () => {
   const options = {};
   props.filters.filters.forEach(element => {
     if (element.type === 'dateRange') {
-      options[element.name + 'From'] = '';
-      options[element.name + 'To'] = '';
+      options[element.name + 'From'] = element.defaultFromValue || '';
+      options[element.name + 'To'] = element.defaultToValue || '';
       return;
     }
-    options[element.name] = '';
+    options[element.name] = element.defaultValue || '';
   });
   searchOptions.value = options;
 };
@@ -111,20 +111,22 @@ defineExpose({
         class="flex items-center gap-2"
         :class="(filter.type === 'dateRange' || filter.type === 'textarea') ? 'col-span-2' : 'col-span-1'"
       >
-        <span class="text-lg font-medium text-gray-700 whitespace-nowrap w-28 flex-shrink-0 text-center">{{ filter.label }}</span>
+        <span class="text-lg font-medium whitespace-nowrap w-28 flex-shrink-0 text-center">{{ filter.label }}</span>
 
         <!-- Text Input -->
         <InputText v-if="filter.type === 'text'" :id="'filter-' + rowIndex + '-' + filterIndex" type="text"
-          v-model="searchOptions[filter.name]" :placeholder="filter.placeholder || 'Enter text...'" class="flex-1" />
+          v-model="searchOptions[filter.name]" :placeholder="filter.placeholder || 'Enter text...'" 
+          :disabled="filter.disabled || false" class="flex-1" />
 
         <!-- Textarea Input -->
         <Textarea v-else-if="filter.type === 'textarea'" :id="'filter-' + rowIndex + '-' + filterIndex"
-          v-model="searchOptions[filter.name]" :placeholder="filter.placeholder || 'Enter text...'" class="flex-1" rows="3" />
+          v-model="searchOptions[filter.name]" :placeholder="filter.placeholder || 'Enter text...'" 
+          :disabled="filter.disabled || false" class="flex-1" rows="3" />
         
         <!-- Date Picker -->
         <DatePicker v-else-if="filter.type === 'date'" :id="'filter-' + rowIndex + '-' + filterIndex"
           v-model="searchOptions[filter.name]" :placeholder="filter.placeholder || 'Select date...'"
-          dateFormat="yy-mm-dd" class="flex-1" :show-icon="true" :show-button-bar="true"/>
+          dateFormat="yy-mm-dd" :disabled="filter.disabled || false" class="flex-1" :show-icon="true" :show-button-bar="true"/>
 
         <!-- Date Picker From To -->
         <DatePickerFromTo v-else-if="filter.type === 'dateRange'" 
@@ -132,26 +134,39 @@ defineExpose({
           v-model:toValue="searchOptions[filter.name + 'To']" 
           :fromPlaceholder="filter.fromPlaceholder"
           :toPlaceholder="filter.toPlaceholder" 
+          :disabled="filter.disabled || false"
           class="flex-1" />
 
         <!-- Number Input -->
         <InputNumber v-else-if="filter.type === 'number'" :id="'filter-' + rowIndex + '-' + filterIndex"
-          v-model="searchOptions[filter.name]" :placeholder="filter.placeholder || 'Enter number...'" class="flex-1" />
+          v-model="searchOptions[filter.name]" :placeholder="filter.placeholder || 'Enter number...'" 
+          :disabled="filter.disabled || false" class="flex-1" />
 
         <!-- Select Input -->
         <Select v-else-if="filter.type === 'select'" :id="'filter-' + rowIndex + '-' + filterIndex"
           v-model="searchOptions[filter.name]" :options="filter.options" showClear
-          optionLabel="name" optionValue="value" :placeholder="filter.placeholder || 'Select option...'" class="flex-1" />
+          optionLabel="name" optionValue="value" :placeholder="filter.placeholder || 'Select option...'" 
+          :disabled="filter.disabled || false" class="flex-1" />
 
         <!-- Item Search -->
         <InputGroup v-else-if="filter.type === 'item-search'" class="flex-1">
-          <InputText :id="'filter-' + rowIndex + '-' + filterIndex" v-model="searchOptions[filter.name]" :placeholder="filter.placeholder || 'Enter item name...'" />
-          <Button icon="pi pi-search" class="p-button-outlined" @click="openSearchModal(filter.name)" />
+          <InputText 
+            :id="'filter-' + rowIndex + '-' + filterIndex" 
+            v-model="searchOptions[filter.name]" 
+            :placeholder="filter.placeholder || 'Enter item name...'" 
+            :readonly="filter.disabled || false"
+            :disabled="filter.disabled || false" />
+          <Button 
+            icon="pi pi-search" 
+            class="p-button-outlined" 
+            :disabled="filter.disabled || false"
+            @click="openSearchModal(filter.name)" />
         </InputGroup>
 
         <!-- Default fallback to text input -->
         <InputText v-else :id="'filter-' + rowIndex + '-' + filterIndex" type="text"
-          v-model="searchOptions[filter.name]" :placeholder="filter.placeholder || 'Enter text...'" class="flex-1" />
+          v-model="searchOptions[filter.name]" :placeholder="filter.placeholder || 'Enter text...'" 
+          :disabled="filter.disabled || false" class="flex-1" />
       </div>
 
       <!-- 빈 공간은 Grid에서 자동으로 처리됨 -->

--- a/client/src/layout/AppMenu.vue
+++ b/client/src/layout/AppMenu.vue
@@ -58,7 +58,7 @@ const model = ref([
         items: [
             { label: '매출 계획 조회', icon: 'pi pi-fw pi-book', to: '/sales/plan' },
             { label: '주문 등록', icon: 'pi pi-fw pi-book', to: '/sales/orders' },
-            { label: '주문 조회', icon: 'pi pi-fw pi-book', to: '/sales/orders/view' },
+            { label: '주문 조회 및 정산', icon: 'pi pi-fw pi-book', to: '/sales/orders/view' },
             { label: '판매 이력 조회', icon: 'pi pi-fw pi-book', to: '/sales/history' },
         ]
     },

--- a/client/src/views/sales/SalesHistoryPage.vue
+++ b/client/src/views/sales/SalesHistoryPage.vue
@@ -7,9 +7,23 @@ import { useAuth } from '@/composables/useAuth';
 
 const { user } = useAuth();
 
+// 최근 일주일 날짜 범위 계산
+const getLastWeekDates = () => {
+  const today = new Date();
+  const lastWeek = new Date();
+  lastWeek.setDate(today.getDate() - 7);
+  
+  return {
+    from: lastWeek.toISOString().split('T')[0], // YYYY-MM-DD 형식
+    to: today.toISOString().split('T')[0]
+  };
+};
+
+const lastWeekDates = getLastWeekDates();
+
 // 조회 폼의 헤더 정보 (조회 테이블 컬럼 이름)
 const header = ref({
-  title: '판매 이력 검색', // 조회 폼 제목
+  title: '판매 이력 조회', // 조회 폼 제목
   header: { // 테이블의 헤더 정보
     productId: '제품번호', 
     productName: '제품명', 
@@ -29,7 +43,7 @@ const items = ref([]);
 
 // 검색 조건 필터 설정
 const filters = ref({});
-filters.value.title = '매출 검색'; // 검색 조건 폼 제목
+filters.value.title = '판매 이력 검색'; // 검색 조건 폼 제목
 
 // 사용자 권한에 따른 지점명 필터 설정
 const isHeadquarters = user.value?.compId === 'COM10001';
@@ -39,11 +53,21 @@ const storeFilter = {
   value: '',
   placeholder: '지점명 검색',
   name: 'store',
-  disabled: !isHeadquarters // 본사가 아니면 비활성화
+  disabled: !isHeadquarters, // 본사가 아니면 비활성화
+  defaultValue: '' // 동적으로 설정될 예정
 };
 
 filters.value.filters = [
-  { type: 'dateRange', label: '매출기간', value: '', fromPlaceholder: '', name: 'salesDates' },
+  { 
+    type: 'dateRange', 
+    label: '매출기간', 
+    value: '', 
+    fromPlaceholder: '시작일', 
+    toPlaceholder: '종료일',
+    name: 'salesDates',
+    defaultFromValue: lastWeekDates.from,
+    defaultToValue: lastWeekDates.to
+  },
   { type: 'item-search', label: '제품명', value: '', placeholder: '제품 검색', name: 'products' },
   { type: 'item-search', label: '제품분류', value: '', placeholder: '제품분류 검색', name: 'productType' },
   storeFilter,
@@ -311,17 +335,31 @@ const loadSalesHistory = async () => {
 
         searchFormRef.value.searchFormRef.searchOptions.store = firstData.compName;
         searchComp = firstData.compName;
+        
+        // 본사 직원의 defaultValue도 설정
+        const storeFilterIndex = filters.value.filters.findIndex(f => f.name === 'store');
+        if (storeFilterIndex !== -1) {
+          filters.value.filters[storeFilterIndex].defaultValue = firstData.compName;
+        }
       }
       // 본사는 지점 필터 활성화
       const storeFilterIndex = filters.value.filters.findIndex(f => f.name === 'store');
       if (storeFilterIndex !== -1) {
         filters.value.filters[storeFilterIndex].disabled = false;
       }
+    } else {
+      // 지점 직원의 defaultValue 설정
+      const storeFilterIndex = filters.value.filters.findIndex(f => f.name === 'store');
+      if (storeFilterIndex !== -1) {
+        filters.value.filters[storeFilterIndex].defaultValue = user.value?.compName || '';
+      }
     }
 
     const response = await axios.get('/api/sales/history/search', {
       params: {
         compName: searchComp,
+        salesDatesFrom: lastWeekDates.from,
+        salesDatesTo: lastWeekDates.to
       }
     });
     items.value = await response.data; // 서버에서 받은 데이터를 items에 저장
@@ -331,9 +369,35 @@ const loadSalesHistory = async () => {
   }
 };
 
-const resetList = () => {
-  loadSalesHistory();
-}
+const resetList = async () => {
+  // SearchForm의 초기화 기능을 활용 (defaultValue 자동 적용)
+  let defaultStore = '';
+  
+  if (!isHeadquarters) {
+    // 지점 직원: 자신의 지점명
+    defaultStore = user.value?.compName || '';
+  } else {
+    // 본사 직원: 첫 번째 지점명을 가져와서 설정
+    try {
+      const response = await axios.get('/api/search/branches/all');
+      const firstData = await response.data[0];
+      defaultStore = firstData?.compName || '';
+      
+      // 검색 폼의 지점명도 업데이트
+      if (searchFormRef.value?.searchFormRef?.searchOptions) {
+        searchFormRef.value.searchFormRef.searchOptions.store = defaultStore;
+      }
+    } catch (error) {
+      console.error('Error loading branches for reset:', error);
+    }
+  }
+  
+  searchSalesHistory({
+    store: defaultStore,
+    salesDatesFrom: lastWeekDates.from,
+    salesDatesTo: lastWeekDates.to
+  });
+};
 
 onMounted(() => {
   loadSalesHistory();

--- a/client/src/views/sales/SalesOrdersMgmt.vue
+++ b/client/src/views/sales/SalesOrdersMgmt.vue
@@ -4,6 +4,7 @@ import { onBeforeMount, onMounted, ref, watch } from 'vue';
 import { convertDate } from '@/utils/dateUtils';
 import { useAuth } from '@/composables/useAuth';
 import { useConfirm } from 'primevue';
+import { useToast } from 'primevue';
 import axios from '@/service/axios';
 import DialogModal from '@/components/overray/DialogModal.vue';
 
@@ -11,6 +12,7 @@ import DialogModal from '@/components/overray/DialogModal.vue';
 
 const inputRef = ref(null);
 const confirm = useConfirm(); //confirm
+const toast = useToast(); // toast
 
 // 폼 기본값
 const defaultForm = ref({
@@ -126,25 +128,69 @@ const tableSearch = async (item, fieldName, data) => {
 }
 
 const fetchSalesOrders = async (formData, tableData) => {
-  //총 가격
-  const totalPrice = parseInt(String(formData.totalPrice).replace(/[,원]/g, ''));
-  // 주문서 등록
-  const res = await axios.post('/api/sales/orders', {
-    orders: {
-      ...formData,
-      paymentType: formData.paymentType.value,
-      totalPrice
-    },
-    ordersDetail: tableData.map((item) => {
-      return {
-        productId: item.productId,
-        quantity: item.quantity,
-        price: parseInt(String(item.total).replace(/[,원]/g, '')),
-      };
-    })
-  });
-  console.log(res.data);
+  try {
+    //총 가격
+    const totalPrice = parseInt(String(formData.totalPrice).replace(/[,원]/g, ''));
+    // 주문서 등록
+    const res = await axios.post('/api/sales/orders', {
+      orders: {
+        ...formData,
+        paymentType: formData.paymentType.value,
+        totalPrice
+      },
+      ordersDetail: tableData.map((item) => {
+        return {
+          productId: item.productId,
+          quantity: item.quantity,
+          price: parseInt(String(item.total).replace(/[,원]/g, '')),
+        };
+      })
+    });
+    
+    console.log('주문서 등록 성공:', res.data);
+    
+    // 성공 토스트 메시지
+    toast.add({
+      severity: 'success',
+      summary: '등록 완료',
+      detail: '주문서가 성공적으로 등록되었습니다.',
+      life: 3000
+    });
+    
+    // 폼과 테이블 초기화
+    resetFormAndTable();
+    
+  } catch (error) {
+    console.error('주문서 등록 실패:', error);
+    
+    // 실패 토스트 메시지
+    toast.add({
+      severity: 'error',
+      summary: '등록 실패',
+      detail: '주문서 등록 중 오류가 발생했습니다.',
+      life: 5000
+    });
+  }
 }
+
+// 폼과 테이블 초기화 함수
+const resetFormAndTable = () => {
+  // 폼 데이터 초기화
+  if (inputRef.value) {
+    const formData = inputRef.value.getFormData();
+    formData.value = {
+      ...defaultForm.value,
+      soDate: convertDate(new Date()),
+      totalPrice: '0원',
+    };
+    
+    // 테이블 데이터 초기화
+    const tableDataRef = inputRef.value.getTableData();
+    if (tableDataRef.value) {
+      tableDataRef.value.splice(0);
+    }
+  }
+};
 
 // 폼과 테이블 데이터를 저장하는 핸들러
 const saveFormHandler = async (formData, tableData) => {
@@ -242,6 +288,7 @@ onMounted(() => {
 });
 </script>
 <template>
+  <Toast />
   <ConfirmDialog />
   <InputDataTable ref="inputRef" title="주문정보" tableTitle="상품목록"
     :defaultForm="defaultForm" :formSchema="formSchema"

--- a/client/src/views/sales/SalesOrdersPage.vue
+++ b/client/src/views/sales/SalesOrdersPage.vue
@@ -2,10 +2,28 @@
 import { onMounted, ref } from 'vue';
 import BasicTable from '@/components/table/BasicTable.vue';
 import SearchForm from '@/components/inputForm/SearchForm.vue';
+import DialogModal from '@/components/overray/DialogModal.vue';
+import Button from 'primevue/button';
+import Dialog from 'primevue/dialog';
+import Calendar from 'primevue/calendar';
+import { useToast } from 'primevue/usetoast';
 import { useAuth } from '@/composables/useAuth';
 import axios from '@/service/axios';
 
 const searchFormRef = ref(null);
+const { user } = useAuth();
+const toast = useToast();
+
+// 일일 정산 관련 변수들
+const dailySettlementVisible = ref(false);
+const todaySalesData = ref({
+  totalAmount: 0,
+  orderCount: 0,
+  settlementDate: null,  // Date 객체로 변경
+  cashAmount: 0,         // 현금
+  transferAmount: 0,     // 계좌이체
+  cardAmount: 0,         // 카드결제
+});
 
 // 마스터 테이블
 const masterHeader = ref({
@@ -64,7 +82,7 @@ const onRowUnselect = (row) => {
 const filters = ref({
   title: '조회 조건',
   filters: [
-    { type: 'text', label: '주문코드', value: '', placeholder: '주문코드를 입력하세요.', name: 'soId' },
+    { type: 'item-search', label: '주문코드', value: '', placeholder: '주문코드를 입력하세요.', name: 'soId' },
     { type: 'select', label: '결제방식', value: '', placeholder: '결제방식을 선택하세요.', name: 'paymentType',
         options: [
         { name: '현금', value: '160001' },
@@ -74,7 +92,10 @@ const filters = ref({
     },
     { type: 'dateRange', label: '주문일자', value: '', name: 'soDate',
       fromPlaceholder: '예: 2025-07-01', toPlaceholder: '예: 2025-07-31' },
-    { type: 'text', label: '지점명', value: '', placeholder: '지점명을 입력하세요.', name: 'compName' },
+    { type: 'item-search', label: '지점명', value: '', placeholder: '지점명을 입력하세요.', name: 'compName',
+      disabled: user.value?.compId !== 'COM10001', // 본사가 아니면 비활성화
+      defaultValue: '' // 동적으로 설정될 예정
+    },
     { type: 'select', label: '상태', value: '', placeholder: '주문상태를 선택하세요.', name: 'status',
       options: [
         { name: '판매됨', value: '020001' },
@@ -85,21 +106,101 @@ const filters = ref({
   ]
 });
 
+// 모달 관련 변수들
+const orderCodeModalVisible = ref(false);
+const storeModalVisible = ref(false);
+
+// 모달창의 테이블 헤더 정보
+const orderHeaders = ref([
+  { field: 'soId', header: '주문코드' },
+  { field: 'compName', header: '지점명' },
+  { field: 'soDate', header: '주문일자' },
+  { field: 'totalPrice', header: '총액' },
+  { field: 'statusName', header: '상태' },
+]);
+
+const storeHeaders = ref([
+  { field: 'compId', header: 'ID' },
+  { field: 'compName', header: '회사명' },
+  { field: 'ceoName', header: '대표자' },
+  { field: 'phone', header: '전화번호' },
+]);
+
+// 모달창의 데이터 아이템
+const orderItems = ref([]);
+const storeItems = ref([]);
+
 const filterOptions = ref({}); // 검색 조건 기본값
 
 const searchData = async (searchValue) => {
-  getSalesOrders(searchValue);
+  // 날짜를 문자열로 변환 (로컬 시간 기준)
+  const params = { ...searchValue };
+  if (params.soDateFrom && typeof params.soDateFrom !== 'string') {
+    const date = new Date(params.soDateFrom);
+    params.soDateFrom = date.getFullYear() + '-' + 
+                        String(date.getMonth() + 1).padStart(2, '0') + '-' + 
+                        String(date.getDate()).padStart(2, '0');
+  }
+  if (params.soDateTo && typeof params.soDateTo !== 'string') {
+    const date = new Date(params.soDateTo);
+    params.soDateTo = date.getFullYear() + '-' + 
+                      String(date.getMonth() + 1).padStart(2, '0') + '-' + 
+                      String(date.getDate()).padStart(2, '0');
+  }
+  
+  getSalesOrders(params);
 };
 
-const resetSearchData = () => {
-  searchFormRef.value.searchOptions = { ...filterOptions.value }; //기본값으로 초기화
+const resetSearchData = async () => {
+  // 사용자 권한에 따른 지점명 재설정
+  let defaultCompName = '';
+  
+  if (user.value && user.value.compId && user.value.compId !== 'COM10001') {
+    // 지점 직원: 자신의 지점명
+    defaultCompName = user.value.compName;
+  } else if (user.value && user.value.compId === 'COM10001') {
+    // 본사 직원: 첫 번째 지점명
+    try {
+      const response = await axios.get('/api/search/branches/all');
+      const firstData = await response.data[0];
+      defaultCompName = firstData?.compName || '';
+    } catch (error) {
+      console.error('Error loading branches for reset:', error);
+    }
+  }
+  
+  // 기본값에 지점명 설정
+  const resetOptions = { ...filterOptions.value };
+  if (defaultCompName) {
+    resetOptions.compName = defaultCompName;
+  }
+  
+  searchFormRef.value.searchOptions = resetOptions; //기본값으로 초기화
+  
+  // 검색폼의 지점명 필드도 업데이트
+  if (searchFormRef.value.searchFormRef?.searchOptions && defaultCompName) {
+    searchFormRef.value.searchFormRef.searchOptions.compName = defaultCompName;
+  }
 };
 
 const getSalesOrders = async (searchValue) => {
+  // 날짜를 문자열로 변환 (로컬 시간 기준)
+  const params = { ...searchValue };
+  if (params.soDateFrom && typeof params.soDateFrom !== 'string') {
+    const date = new Date(params.soDateFrom);
+    params.soDateFrom = date.getFullYear() + '-' + 
+                        String(date.getMonth() + 1).padStart(2, '0') + '-' + 
+                        String(date.getDate()).padStart(2, '0');
+  }
+  if (params.soDateTo && typeof params.soDateTo !== 'string') {
+    const date = new Date(params.soDateTo);
+    params.soDateTo = date.getFullYear() + '-' + 
+                      String(date.getMonth() + 1).padStart(2, '0') + '-' + 
+                      String(date.getDate()).padStart(2, '0');
+  }
+  
   const res = await axios.get('/api/sales/orders', {
-    params: {
-      ...searchValue
-    }
+    params: params
   });
   if (res.data?.length > 0) {
     masterItems.value = res.data.map((e) => {
@@ -137,11 +238,13 @@ const defaultFilterOptions = async (userInfo) => {
     }
   }); //filtrer의 name을 key로 사용
 
-  // 기본 날짜 설정
-  const defaultOrderDateFrom = new Date();
-  // 1년 전부터 조회하기 위해 기본 날짜 설정
-  defaultOrderDateFrom.setFullYear(defaultOrderDateFrom.getFullYear() - 1);
-  options.soDateFrom = defaultOrderDateFrom;
+  // 기본 날짜 설정 - 최근 일주일
+  const today = new Date();
+  const lastWeek = new Date();
+  lastWeek.setDate(today.getDate() - 7);
+  
+  options.soDateFrom = lastWeek.toISOString().split('T')[0]; // YYYY-MM-DD 형식
+  options.soDateTo = today.toISOString().split('T')[0];
 
   // 지점 정보 기져오기
   const branchInfo = await getBranchInfo(userInfo.employeeId);
@@ -151,11 +254,223 @@ const defaultFilterOptions = async (userInfo) => {
   filterOptions.value = { ...options };
 }
 
+// 모달 관련 함수들
+const loadOrderItems = async () => {
+  try {
+    const response = await axios.get('/api/sales/orders');
+    orderItems.value = await response.data;
+    console.log('Order items loaded:', orderItems.value);
+  } catch (error) {
+    console.error('Error loading order items:', error);
+  }
+};
+
+const loadStoreItems = async () => {
+  try {
+    const response = await axios.get('/api/search/branches/all');
+    storeItems.value = await response.data;
+    console.log('Store items loaded:', storeItems.value);
+  } catch (error) {
+    console.error('Error loading store items:', error);
+  }
+};
+
+const handleOpenModal = async (filterName) => {
+  console.log('Open modal for filter:', filterName);
+  
+  // 지점 직원이 지점명 모달을 열려고 하면 차단
+  if (filterName === 'compName' && user.value?.compId !== 'COM10001') {
+    console.warn('Branch employees cannot change store filter');
+    return;
+  }
+  
+  switch (filterName) {
+    case 'soId':
+      loadOrderItems();
+      orderCodeModalVisible.value = true;
+      break;
+    case 'compName':
+      loadStoreItems();
+      storeModalVisible.value = true;
+      break;
+    default:
+      console.warn('No modal defined for filter:', filterName);
+  }
+};
+
+// 모달창 닫기 함수
+const closeOrderModal = () => {
+  orderCodeModalVisible.value = false;
+}
+
+const closeStoreModal = () => {
+  storeModalVisible.value = false;
+}
+
+// SearchForm의 값 업데이트 함수
+const updateFilterValue = (filterName, selectedItem) => {
+  if (searchFormRef.value.searchOptions) {
+    searchFormRef.value.searchOptions[filterName] = selectedItem;
+  }
+};
+
+// 모달창 확인 버튼 함수
+const confirmOrderModal = (selectedItems) => {
+  console.log('Selected items from order modal:', selectedItems);
+  if (selectedItems) {
+    updateFilterValue('soId', selectedItems.soId);
+  }
+  orderCodeModalVisible.value = false;
+};
+
+const confirmStoreModal = (selectedItems) => {
+  console.log('Selected items from store modal:', selectedItems);
+  if (selectedItems) {
+    updateFilterValue('compName', selectedItems.compName);
+  }
+  storeModalVisible.value = false;
+};
+
+// 일일 정산 관련 함수들
+const openDailySettlement = async () => {
+  try {
+    // 오늘 날짜 설정 (Date 객체로)
+    const today = new Date();
+    todaySalesData.value.settlementDate = today;
+    
+    // 초기 데이터 로드
+    await loadDailySalesData(today);
+    
+    dailySettlementVisible.value = true;
+  } catch (error) {
+    console.error('Error opening daily settlement:', error);
+    toast.add({
+      severity: 'error',
+      summary: '오류',
+      detail: '일일 정산 모달을 여는데 실패했습니다.',
+      life: 3000
+    });
+  }
+};
+
+// 선택된 날짜의 판매 데이터 로드
+const loadDailySalesData = async (selectedDate) => {
+  try {
+    const dateString = selectedDate.getFullYear() + '-' + 
+                      String(selectedDate.getMonth() + 1).padStart(2, '0') + '-' + 
+                      String(selectedDate.getDate()).padStart(2, '0');
+    
+    const response = await axios.get('/api/sales/daily-summary', {
+      params: {
+        compId: user.value.compId,
+        date: dateString
+      }
+    });
+    
+    if (response.data) {
+      todaySalesData.value.totalAmount = response.data.totalAmount || 0;
+      todaySalesData.value.orderCount = response.data.orderCount || 0;
+      todaySalesData.value.cashAmount = response.data.cashAmount || 0;
+      todaySalesData.value.transferAmount = response.data.transferAmount || 0;
+      todaySalesData.value.cardAmount = response.data.cardAmount || 0;
+    }
+  } catch (error) {
+    console.error('Error loading daily sales data:', error);
+    toast.add({
+      severity: 'error',
+      summary: '오류',
+      detail: '선택한 날짜의 판매 데이터를 불러오는데 실패했습니다.',
+      life: 3000
+    });
+  }
+};
+
+// 정산 날짜 변경 시 호출
+const onSettlementDateChange = async () => {
+  if (todaySalesData.value.settlementDate) {
+    await loadDailySalesData(todaySalesData.value.settlementDate);
+  }
+};
+
+const confirmDailySettlement = async () => {
+  try {
+    // Date 객체를 문자열로 변환
+    const dateString = todaySalesData.value.settlementDate.getFullYear() + '-' + 
+                      String(todaySalesData.value.settlementDate.getMonth() + 1).padStart(2, '0') + '-' + 
+                      String(todaySalesData.value.settlementDate.getDate()).padStart(2, '0');
+    
+    const settlementData = {
+      compId: user.value.compId,
+      closingDate: dateString,
+      totalPrice: todaySalesData.value.totalAmount
+    };
+    
+    await axios.post('/api/sales/dailyClosing', settlementData);
+    
+    toast.add({
+      severity: 'success',
+      summary: '정산 완료',
+      detail: '일일 정산이 완료되었습니다.',
+      life: 3000
+    });
+    
+    dailySettlementVisible.value = false;
+  } catch (error) {
+    console.error('Error processing daily settlement:', error);
+    toast.add({
+      severity: 'error',
+      summary: '정산 실패',
+      detail: '일일 정산 처리에 실패했습니다.',
+      life: 3000
+    });
+  }
+};
+
+const closeDailySettlement = () => {
+  dailySettlementVisible.value = false;
+};
+
 onMounted(async () => {
   //사용자 정보
   const userInfo = useAuth().user.value;
+  
+  // 지점 정보에 따른 필터 설정
+  let defaultCompName = '';
+  
+  if (userInfo && userInfo.compId && userInfo.compId !== 'COM10001') {
+    // 지점 직원: 자신의 지점명으로 설정하고 비활성화
+    defaultCompName = userInfo.compName;
+    const compNameFilterIndex = filters.value.filters.findIndex(f => f.name === 'compName');
+    if (compNameFilterIndex !== -1) {
+      filters.value.filters[compNameFilterIndex].disabled = true;
+      filters.value.filters[compNameFilterIndex].value = defaultCompName;
+      filters.value.filters[compNameFilterIndex].defaultValue = defaultCompName;
+    }
+  } else if (userInfo && userInfo.compId === 'COM10001') {
+    // 본사 직원: 첫 번째 지점명으로 설정하고 활성화
+    try {
+      const response = await axios.get('/api/search/branches/all');
+      const firstData = await response.data[0];
+      defaultCompName = firstData?.compName || '';
+      
+      const compNameFilterIndex = filters.value.filters.findIndex(f => f.name === 'compName');
+      if (compNameFilterIndex !== -1) {
+        filters.value.filters[compNameFilterIndex].disabled = false;
+        filters.value.filters[compNameFilterIndex].defaultValue = defaultCompName;
+      }
+    } catch (error) {
+      console.error('Error loading branches for headquarters:', error);
+    }
+  }
+  
   // 검색조건 기본값 설정
   await defaultFilterOptions(userInfo);
+  
+  // 지점명 기본값 추가 설정
+  if (defaultCompName) {
+    filterOptions.value.compName = defaultCompName;
+  }
+  
   resetSearchData();
   // 주문서 정보 조회
   getSalesOrders(filterOptions.value);
@@ -164,7 +479,117 @@ onMounted(async () => {
 <template>
   <SearchForm ref="searchFormRef" :filters="filters" 
     @searchData="searchData" @resetSearchOptions="resetSearchData"
+    @open-search-modal="handleOpenModal"
+    :defaultValues="filterOptions"
   />
-  <BasicTable :data="masterItems" :header="masterHeader" :checked="true" :dataKey="'soId'" @rowSelect="onRowSelect" @rowUnselect="onRowUnselect"></BasicTable>
-  <BasicTable :data="detailItems" :header="detailHeader"></BasicTable>
+  
+  <!-- 지점 직원용 일일 정산 버튼 -->
+  <div v-if="user?.compId !== 'COM10001'" class="mb-3">
+    <Button 
+      label="일일 정산" 
+      icon="pi pi-calculator" 
+      class="p-button-info"
+      @click="openDailySettlement"
+    />
+  </div>
+  
+  <BasicTable :data="masterItems" :header="masterHeader" :checked="true" :dataKey="'soId'" @rowSelect="onRowSelect" @rowUnselect="onRowUnselect" :scrollHeight="'200px'"></BasicTable>
+  <BasicTable :data="detailItems" :header="detailHeader" :scrollHeight="'200px'"></BasicTable>
+  
+  <!-- 주문코드 선택 모달 -->
+  <DialogModal v-model:display="orderCodeModalVisible" :items="orderItems" :headers="orderHeaders" title="주문코드 검색"
+    selectionMode="single" @close="closeOrderModal" @confirm="confirmOrderModal" />
+  
+  <!-- 지점 선택 모달 -->
+  <DialogModal v-model:display="storeModalVisible" :items="storeItems" :headers="storeHeaders" title="지점 검색"
+    selectionMode="single" @close="closeStoreModal" @confirm="confirmStoreModal" />
+  
+  <!-- 일일 정산 모달 -->
+  <Dialog 
+    v-model:visible="dailySettlementVisible" 
+    header="일일 정산" 
+    :modal="true" 
+    :closable="true"
+    :style="{ width: '400px' }"
+    @hide="closeDailySettlement"
+  >
+    <div class="p-4">
+      <!-- 정산 날짜 선택 -->
+      <div class="mb-4">
+        <label class="block text-sm font-medium mb-2">정산 날짜</label>
+        <Calendar 
+          v-model="todaySalesData.settlementDate" 
+          :showIcon="true"
+          dateFormat="yy-mm-dd"
+          :maxDate="new Date()"
+          @date-select="onSettlementDateChange"
+          placeholder="정산할 날짜를 선택하세요"
+          class="w-full"
+        />
+      </div>
+      
+      <div class="mb-4" v-if="todaySalesData.settlementDate">
+        <h4 class="text-lg font-semibold mb-2">
+          {{ todaySalesData.settlementDate.toLocaleDateString('ko-KR') }} 판매 현황
+        </h4>
+      </div>
+      
+      <div class="grid grid-cols-1 gap-4 mb-6" v-if="todaySalesData.settlementDate">
+        <div class="p-3 border rounded-lg bg-gray-50">
+          <div class="text-sm text-gray-600">총 주문 건수</div>
+          <div class="text-xl font-bold">{{ todaySalesData.orderCount }}건</div>
+        </div>
+        
+        <div class="p-3 border rounded-lg bg-blue-50">
+          <div class="text-sm text-gray-600">총 판매 금액</div>
+          <div class="text-2xl font-bold text-blue-600">
+            {{ Number(todaySalesData.totalAmount).toLocaleString() }}원
+          </div>
+        </div>
+        
+        <!-- 결제 방식별 금액 -->
+        <div class="grid grid-cols-3 gap-2">
+          <div class="p-2 border rounded bg-green-50">
+            <div class="text-xs text-gray-600">현금</div>
+            <div class="text-sm font-semibold text-green-600">
+              {{ Number(todaySalesData.cashAmount).toLocaleString() }}원
+            </div>
+          </div>
+          
+          <div class="p-2 border rounded bg-yellow-50">
+            <div class="text-xs text-gray-600">계좌이체</div>
+            <div class="text-sm font-semibold text-yellow-600">
+              {{ Number(todaySalesData.transferAmount).toLocaleString() }}원
+            </div>
+          </div>
+          
+          <div class="p-2 border rounded bg-purple-50">
+            <div class="text-xs text-gray-600">카드결제</div>
+            <div class="text-sm font-semibold text-purple-600">
+              {{ Number(todaySalesData.cardAmount).toLocaleString() }}원
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <div class="text-center" v-if="todaySalesData.settlementDate">
+        <p class="text-gray-600 mb-4">위 금액으로 정산을 진행하시겠습니까?</p>
+        
+        <div class="flex justify-center gap-2">
+          <Button 
+            label="취소" 
+            icon="pi pi-times" 
+            class="p-button-secondary"
+            @click="closeDailySettlement"
+          />
+          <Button 
+            label="정산하기" 
+            icon="pi pi-check" 
+            class="p-button-success"
+            @click="confirmDailySettlement"
+          />
+        </div>
+      </div>
+    </div>
+  </Dialog>
 </template>

--- a/server/src/main/java/com/olivin/app/common/mapper/DataCodeMapper.java
+++ b/server/src/main/java/com/olivin/app/common/mapper/DataCodeMapper.java
@@ -1,0 +1,18 @@
+package com.olivin.app.common.mapper;
+
+/**
+ * 데이터 코드 매퍼 인터페이스 <br>
+ * 데이터 코드와 관련된 데이터베이스 작업을 수행하는 매퍼 인터페이스입니다.
+ * 
+ * 작성자: 함동의
+ * 작성일: 2025.08.09
+ * 수정이력:
+ * - 2025.08.09 : 최초 작성
+ */
+public interface DataCodeMapper {
+    // 데이터 코드 값을 받아서 해당 코드의 이름을 반환합니다.
+    public String getCodeName(String codeValue);
+
+    // 데이터 코드의 이름을 받아서 해당 코드의 값을 반환합니다.
+    public String getCodeValue(String codeName);
+}

--- a/server/src/main/java/com/olivin/app/common/service/DataCodeService.java
+++ b/server/src/main/java/com/olivin/app/common/service/DataCodeService.java
@@ -1,0 +1,19 @@
+package com.olivin.app.common.service;
+
+/**
+ * 데이터 코드 서비스 인터페이스 <br>
+ * 데이터 코드와 관련된 기능을 제공하는 서비스 인터페이스입니다.
+ * 데이터 코드를 값으로 변환, 반대로 값을 데이터 코드로 변화하는 서비스를 제공합니다.
+ * 
+ * 작성자: 함동의
+ * 작성일: 2025.08.09
+ * 수정이력:
+ * - 2025.08.09 : 최초 작성
+ */
+public interface DataCodeService {
+    // 데이터 코드 값을 받아서 해당 코드의 이름을 반환합니다.
+    public String getCodeName(String codeValue);
+
+    // 데이커 코드의 이름을 받아서 해당 코드의 값을 반환합니다.
+    public String getCodeValue(String codeName);
+}

--- a/server/src/main/java/com/olivin/app/common/service/DataCodeVO.java
+++ b/server/src/main/java/com/olivin/app/common/service/DataCodeVO.java
@@ -1,0 +1,24 @@
+package com.olivin.app.common.service;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 데이터 코드 VO 클래스 <br>
+ * 데이터 코드와 관련된 정보를 담는 클래스입니다.
+ * 
+ * 작성자: 함동의
+ * 작성일: 2025.08.09
+ * 수정이력:
+ * - 2025.08.09 : 최초 작성
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class DataCodeVO {
+    private String codeValue;
+    private String codeName;
+    private String codeGroup;
+    private String note;
+}

--- a/server/src/main/java/com/olivin/app/common/service/impl/DataCodeServiceImpl.java
+++ b/server/src/main/java/com/olivin/app/common/service/impl/DataCodeServiceImpl.java
@@ -1,0 +1,43 @@
+package com.olivin.app.common.service.impl;
+
+import org.springframework.stereotype.Service;
+
+import com.olivin.app.common.mapper.DataCodeMapper;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 데이터 코드 서비스 구현 클래스 <br>
+ * 데이터 코드와 관련된 기능을 제공하는 서비스 구현 클래스입니다.
+ * 데이터 코드를 값으로 변환, 반대로 값을 데이터 코드로 변화하는 서비스를 제공합니다.
+ * 
+ * 작성자: 함동의
+ * 작성일: 2025.08.09
+ * 수정이력:
+ * - 2025.08.09 : 최초 작성
+ */
+@Service
+@RequiredArgsConstructor
+public class DataCodeServiceImpl {
+    private final DataCodeMapper dataCodeMapper;
+
+    /**
+     * 데이터 코드 값을 받아서 해당 코드의 이름을 반환합니다.
+     * 
+     * @param codeValue 데이터 코드 값
+     * @return 해당 코드의 이름
+     */
+    public String getCodeName(String codeValue) {
+        return dataCodeMapper.getCodeName(codeValue);
+    }
+
+    /**
+     * 데이터 코드의 이름을 받아서 해당 코드의 값을 반환합니다.
+     * 
+     * @param codeName 데이터 코드 이름
+     * @return 해당 코드의 값
+     */
+    public String getCodeValue(String codeName) {
+        return dataCodeMapper.getCodeValue(codeName);
+    }
+}

--- a/server/src/main/java/com/olivin/app/sales/mapper/SalesOrdersMapper.java
+++ b/server/src/main/java/com/olivin/app/sales/mapper/SalesOrdersMapper.java
@@ -1,7 +1,11 @@
 package com.olivin.app.sales.mapper;
 
 import java.util.List;
+import java.util.Map;
 
+import org.apache.ibatis.annotations.Param;
+
+import com.olivin.app.sales.service.SalesDailyClosingVO;
 import com.olivin.app.sales.service.SalesOrdersDetailVO;
 import com.olivin.app.sales.service.SalesOrdersVO;
 import com.olivin.app.sales.service.SearchSalesOrdersVO;
@@ -11,8 +15,10 @@ import com.olivin.app.sales.service.SearchSalesOrdersVO;
  * <br>
  * 작성자: 이창현<br>
  * 작성일: 2025.08.06<br>
+ * 수정자: 함동의<br>
  * 수정이력:<br>
  * - 2025.08.06 : 최초 작성<br>
+ * - 2025.08.09 : 일일 정산 mapper 추가<br>
  */
 public interface SalesOrdersMapper {
 	//주문서 조회
@@ -22,4 +28,13 @@ public interface SalesOrdersMapper {
 	//주문서 등록
 	public int insertOne(SalesOrdersVO ordersVO);
 	public int insertDetailOne(SalesOrdersDetailVO ordersDetailVO);
+
+	// 일일 정산 등록
+	public int insertDailyClosing(SalesDailyClosingVO dailyClosingVO);
+
+	// 일일 정산 전용 일 매출 조회
+	public double selectDailySummary(SalesDailyClosingVO dailyClosingVO);
+	
+	// 일일 정산을 위한 결제방식별 매출 집계 조회
+	public Map<String, Object> selectDailySummaryByPaymentType(@Param("compId") String compId, @Param("date") String date);
 }

--- a/server/src/main/java/com/olivin/app/sales/service/SalesDailyClosingVO.java
+++ b/server/src/main/java/com/olivin/app/sales/service/SalesDailyClosingVO.java
@@ -1,0 +1,31 @@
+package com.olivin.app.sales.service;
+
+import java.util.Date;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * SalesDailyClosingVO 클래스 <br>
+ * 일일 정산 관련 정보를 담는 Value Object 클래스입니다.
+ * 
+ * 작성자: 함동의
+ * 작성일: 2025.08.09
+ * 수정이력:
+ * - 2025.08.09 : 최초 작성
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SalesDailyClosingVO {
+    private String compId; // 회사 ID
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private Date closingDate; // 정산 날짜
+    private int totalPrice; // 총 매출액
+}

--- a/server/src/main/java/com/olivin/app/sales/service/SalesOrdersService.java
+++ b/server/src/main/java/com/olivin/app/sales/service/SalesOrdersService.java
@@ -1,20 +1,32 @@
 package com.olivin.app.sales.service;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * 주문서에 관련된 service를 저장되는 인터페이스<br>
  * <br>
  * 작성자: 이창현<br>
  * 작성일: 2025.08.06<br>
+ * 수정자: 함동의<br>
  * 수정이력:<br>
  * - 2025.08.06 : 최초 작성<br>
+ * - 2025.08.09 : 일일 정산 서비스 추가<br>
  */
 public interface SalesOrdersService {
 	//주문서 조회
-	List<SalesOrdersVO> getAllOrders(SearchSalesOrdersVO searchVO);
-	SalesOrdersVO getOneOrders(String orderId);
-	List<SalesOrdersDetailVO> getDetailOrders(String orderId);
+	public List<SalesOrdersVO> getAllOrders(SearchSalesOrdersVO searchVO);
+	public SalesOrdersVO getOneOrders(String orderId);
+	public List<SalesOrdersDetailVO> getDetailOrders(String orderId);
 	//주문서 등록
-	void createSalesOrders(SalesOrdersVO ordersVO, List<SalesOrdersDetailVO> detailVOList);
+	public void createSalesOrders(SalesOrdersVO ordersVO, List<SalesOrdersDetailVO> detailVOList);
+
+	// 일일 정산 등록
+	public void createDailyClosing(SalesDailyClosingVO dailyClosingVO);
+
+	// 일일 정산 전용 일 매출 조회
+	public double getDailySummary(SalesDailyClosingVO dailyClosingVO);
+	
+	// 일일 정산을 위한 결제방식별 매출 집계 조회
+	public Map<String, Object> getDailySummaryByPaymentType(String compId, String date);
 }

--- a/server/src/main/java/com/olivin/app/sales/service/SearchSalesOrdersVO.java
+++ b/server/src/main/java/com/olivin/app/sales/service/SearchSalesOrdersVO.java
@@ -1,11 +1,5 @@
 package com.olivin.app.sales.service;
 
-import java.util.Date;
-
-import org.springframework.format.annotation.DateTimeFormat;
-
-import com.fasterxml.jackson.annotation.JsonFormat;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -19,6 +13,7 @@ import lombok.NoArgsConstructor;
  * 작성일: 2025.08.07<br>
  * 수정이력:<br>
  * - 2025.08.07 : 최초 작성<br>
+ * - 2025.08.09 : 날짜 타입을 String으로 변경<br>
  */
 @Data
 @Builder
@@ -32,11 +27,6 @@ public class SearchSalesOrdersVO {
 	private Integer totalPrice;
 	private String empName;
 	
-	@DateTimeFormat(pattern = "yyyy-MM-dd")
-  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-	private Date soDateFrom;
-	
-	@DateTimeFormat(pattern = "yyyy-MM-dd")
-  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-	private Date soDateTo;
+	private String soDateFrom;
+	private String soDateTo;
 }

--- a/server/src/main/java/com/olivin/app/sales/service/impl/SalesOrdersServiceImpl.java
+++ b/server/src/main/java/com/olivin/app/sales/service/impl/SalesOrdersServiceImpl.java
@@ -1,11 +1,13 @@
 package com.olivin.app.sales.service.impl;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.olivin.app.sales.mapper.SalesOrdersMapper;
+import com.olivin.app.sales.service.SalesDailyClosingVO;
 import com.olivin.app.sales.service.SalesOrdersDetailVO;
 import com.olivin.app.sales.service.SalesOrdersService;
 import com.olivin.app.sales.service.SalesOrdersVO;
@@ -18,8 +20,10 @@ import lombok.RequiredArgsConstructor;
  * <br>
  * 작성자: 이창현<br>
  * 작성일: 2025.08.06<br>
+ * 수정자: 함동의<br>
  * 수정이력:<br>
  * - 2025.08.06 : 최초 작성<br>
+ * - 2025.08.09 : 일일 정산 서비스 추가<br>
  * @see SalesOrdersService
  */
 @Service
@@ -48,15 +52,34 @@ public class SalesOrdersServiceImpl implements SalesOrdersService {
 		// 1. 메인 주문 정보 등록
 		ordersVO.setStatus("020001"); //판매됨
 		salesOrdersMapper.insertOne(ordersVO);
-    // 2. 상세 주문 정보 리스트 등록
-    if (detailVOList != null && !detailVOList.isEmpty()) {
-    	int count = 0;
-    	for (SalesOrdersDetailVO detailVO : detailVOList) {    		
-    		// 3. 주문서 코드 지정
-    		detailVO.setSodId(ordersVO.getSoId()+String.format("%03d", ++count));
-    		detailVO.setSoId(ordersVO.getSoId());
-    		salesOrdersMapper.insertDetailOne(detailVO);
-    	}
-    }
+		// 2. 상세 주문 정보 리스트 등록
+		if (detailVOList != null && !detailVOList.isEmpty()) {
+			int count = 0;
+			for (SalesOrdersDetailVO detailVO : detailVOList) {    		
+				// 3. 주문서 코드 지정
+				detailVO.setSodId(ordersVO.getSoId()+String.format("%03d", ++count));
+				detailVO.setSoId(ordersVO.getSoId());
+				salesOrdersMapper.insertDetailOne(detailVO);
+			}
+		}
+	}
+
+	@Override
+	@Transactional
+	public void createDailyClosing(SalesDailyClosingVO dailyClosingVO) {
+		// 일일 정산 정보를 등록하는 로직을 구현합니다.
+		salesOrdersMapper.insertDailyClosing(dailyClosingVO);
+	}
+
+	@Override
+	public double getDailySummary(SalesDailyClosingVO dailyClosingVO) {
+		// 일일 정산 전용 일 매출 조회를 위한 로직을 구현합니다.
+		return salesOrdersMapper.selectDailySummary(dailyClosingVO);
+	}
+
+	@Override
+	public Map<String, Object> getDailySummaryByPaymentType(String compId, String date) {
+		// 일일 정산을 위한 결제방식별 매출 집계 조회
+		return salesOrdersMapper.selectDailySummaryByPaymentType(compId, date);
 	}
 }

--- a/server/src/main/java/com/olivin/app/sales/web/SalesOrdersController.java
+++ b/server/src/main/java/com/olivin/app/sales/web/SalesOrdersController.java
@@ -5,13 +5,14 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.olivin.app.sales.service.SalesDailyClosingVO;
 import com.olivin.app.sales.service.SalesOrdersDTO;
 import com.olivin.app.sales.service.SalesOrdersDetailVO;
 import com.olivin.app.sales.service.SalesOrdersService;
@@ -26,8 +27,10 @@ import lombok.extern.slf4j.Slf4j;
  * <br>
  * 작성자: 이창현<br>
  * 작성일: 2025.08.06<br>
+ * 수정자: 함동의<br>
  * 수정이력:<br>
  * - 2025.08.06 : 최초 작성<br>
+ * - 2025.08.09 : 일일 정산 API 추가<br>
  */
 @Slf4j
 @RestController
@@ -37,8 +40,27 @@ public class SalesOrdersController {
 	private final SalesOrdersService salesOrdersService;
 	
 	@GetMapping("/sales/orders")
-	public List<SalesOrdersVO> ordersList(@ModelAttribute SearchSalesOrdersVO search) {
-		log.debug("order = {}", search);
+	public List<SalesOrdersVO> ordersList(
+			@RequestParam(value = "soId", required = false) String soId,
+			@RequestParam(value = "compName", required = false) String compName,
+			@RequestParam(value = "paymentType", required = false) String paymentType,
+			@RequestParam(value = "status", required = false) String status,
+			@RequestParam(value = "empName", required = false) String empName,
+			@RequestParam(value = "soDateFrom", required = false) String soDateFrom,
+			@RequestParam(value = "soDateTo", required = false) String soDateTo) {
+		
+		SearchSalesOrdersVO search = SearchSalesOrdersVO.builder()
+				.soId(soId)
+				.compName(compName)
+				.paymentType(paymentType)
+				.status(status)
+				.empName(empName)
+				.soDateFrom(soDateFrom)
+				.soDateTo(soDateTo)
+				.build();
+		
+		log.debug("order search parameters = {}", search);
+		log.debug("soDateFrom = {}, soDateTo = {}", search.getSoDateFrom(), search.getSoDateTo());
 		return salesOrdersService.getAllOrders(search);
 	}
 	
@@ -75,5 +97,57 @@ public class SalesOrdersController {
 //    result.put("data", orderDTO);
 	    
 	    return result;
+	}
+
+	// 일일 정산을 위한 일일 요약 API
+	@GetMapping("/sales/daily-summary")
+	public Map<String, Object> getDailySummary(
+			@RequestParam(value = "compId", required = false) String compId,
+			@RequestParam(value = "date", required = false) String date) {
+		
+		log.debug("Daily summary request - compId: {}, date: {}", compId, date);
+		
+		Map<String, Object> result = new HashMap<>();
+		
+		try {
+			// 결제 방식별 매출 조회
+			Map<String, Object> dailySummary = salesOrdersService.getDailySummaryByPaymentType(compId, date);
+			
+			// 데이터 매핑 (Oracle의 컬럼명을 camelCase로 변환)
+			result.put("totalAmount", dailySummary.get("TOTAL_AMOUNT"));
+			result.put("orderCount", dailySummary.get("ORDER_COUNT"));
+			result.put("cashAmount", dailySummary.get("CASH_AMOUNT"));
+			result.put("transferAmount", dailySummary.get("TRANSFER_AMOUNT"));
+			result.put("cardAmount", dailySummary.get("CARD_AMOUNT"));
+			
+		} catch (Exception e) {
+			log.error("Error getting daily summary: ", e);
+			result.put("totalAmount", 0);
+			result.put("orderCount", 0);
+			result.put("cashAmount", 0);
+			result.put("transferAmount", 0);
+			result.put("cardAmount", 0);
 		}
+		
+		return result;
+	}
+
+	@PostMapping("/sales/dailyClosing")
+	public Map<String, Object> dailyClosing(@RequestBody SalesDailyClosingVO salesDailyClosingVO) {
+		Map<String, Object> result = new HashMap<>();
+		
+		log.debug("Daily Closing Data: {}", salesDailyClosingVO);
+		
+		try {
+			salesOrdersService.createDailyClosing(salesDailyClosingVO);
+			result.put("result", "SUCCESS");
+			result.put("message", "일일 정산이 완료되었습니다.");
+		} catch (Exception e) {
+			log.error("Error during daily closing: ", e);
+			result.put("result", "FAIL");
+			result.put("message", "일일 정산 중 오류가 발생했습니다.");
+		}
+		
+		return result;
+	}
 }

--- a/server/src/main/resources/mapper/common/branch-company-search-mapper.xml
+++ b/server/src/main/resources/mapper/common/branch-company-search-mapper.xml
@@ -18,6 +18,7 @@
              , note
         FROM   companys
         WHERE  comp_type = '100002'  -- 지점
+          AND  comp_type != 'FFFFFF'  -- 삭제된 지점 제외
         ORDER BY comp_id
     </select>
 
@@ -29,6 +30,7 @@
              , note
         FROM   companys
         WHERE  comp_type = '100002'  -- 지점
+          AND  comp_type != 'FFFFFF'  -- 삭제된 지점 제외
         <if test="searchValue != null and searchValue != ''">
           AND  comp_name LIKE '%' || #{searchValue} || '%'
         </if>

--- a/server/src/main/resources/mapper/common/data-codes-mapper.xml
+++ b/server/src/main/resources/mapper/common/data-codes-mapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.olivin.app.sales.mapper.SalesHistoryMapper">
+    <!-- 데이터 코드 이름 조회 -->
+    <select id="getCodeName" resultType="String" parameterType="String">
+        SELECT get_datacode_name(#{codeValue})
+        FROM   dual
+    </select>
+    
+    <!-- 데이터 코드 값 조회 -->
+    <select id="getCodeValue" resultType="String" parameterType="String">
+        SELECT get_datacode_value(#{codeName})
+        FROM   dual
+    </select>
+</mapper>

--- a/server/src/main/resources/mapper/common/product-search-mapper.xml
+++ b/server/src/main/resources/mapper/common/product-search-mapper.xml
@@ -22,6 +22,7 @@
              , sell_price
              , note
         FROM   products
+        WHERE  status = '040001'
         ORDER BY product_id
     </select>
 
@@ -38,6 +39,7 @@
              , note
         FROM   products
         WHERE  1 = 1
+          AND  status = '040001'
         <if test="searchValue != null and searchValue != ''">
           AND (product_name LIKE '%' || #{searchValue} || '%'
            OR product_id LIKE '%' || #{searchValue} || '%')

--- a/server/src/main/resources/mapper/sales/sales-history-mapper.xml
+++ b/server/src/main/resources/mapper/sales/sales-history-mapper.xml
@@ -3,63 +3,72 @@
 <mapper namespace="com.olivin.app.sales.mapper.SalesHistoryMapper">
     <!-- 판매 이력 전체 조회 -->
     <select id="selectAllSalesHistory" resultType="SalesHistoryVO" parameterType="Map">
-            SELECT p.product_id,
-                   p.product_name,
-                   get_datacode_name(p.category_main) as category_main,
-                   get_datacode_name(p.category_sub) as category_sub,
-                   c.comp_name,
-                   p.sell_price,
-                   SUM(sod.quantity) as quantity,
-                   SUM(sod.quantity * sod.price) as total_price,
-                   p.product_spec || get_datacode_name(p.unit) as product_spec
-            FROM   sales_orders so JOIN sales_orders_detail sod ON so.so_id = sod.so_id
-                                   JOIN products p ON sod.product_id = p.product_id
-                                   JOIN companys c ON so.comp_id = c.comp_id
-            WHERE c.comp_type = '100002'
-            GROUP BY p.product_id, p.product_name, p.category_main, p.category_sub, c.comp_name, p.sell_price, p.product_spec, p.unit
+        SELECT p.product_id,
+               p.product_name,
+               get_datacode_name(p.category_main) as category_main,
+               get_datacode_name(p.category_sub) as category_sub,
+               c.comp_name,
+               p.sell_price,
+               SUM(sod.quantity) as quantity,
+               SUM(sod.quantity * sod.price) as total_price,
+               p.product_spec || get_datacode_name(p.unit) as product_spec
+        FROM   sales_orders so JOIN sales_orders_detail sod ON so.so_id = sod.so_id
+                               JOIN products p ON sod.product_id = p.product_id
+                               JOIN companys c ON so.comp_id = c.comp_id
+        WHERE  c.comp_type = '100002'
+          AND  so.status = '020001'
+        GROUP  BY p.product_id, p.product_name, p.category_main, p.category_sub, c.comp_name, p.sell_price, p.product_spec, p.unit
     </select>
 
     <!-- 조건에 맞는 판매 이력 조회 -->
     <select id="selectSalesHistoryList" parameterType="SalesHistoryVO" resultType="SalesHistoryVO">
-            SELECT p.product_id,
-                   p.product_name,
-                   get_datacode_name(p.category_main) as category_main,
-                   get_datacode_name(p.category_sub) as category_sub,
-                   c.comp_name,
-                   p.sell_price,
-                   SUM(sod.quantity) as quantity,
-                   SUM(sod.quantity * sod.price) as total_price,
-                   p.product_spec || get_datacode_name(p.unit) as product_spec
-            FROM   sales_orders so JOIN sales_orders_detail sod ON so.so_id = sod.so_id
-                                   JOIN products p ON sod.product_id = p.product_id
-                                   JOIN companys c ON so.comp_id = c.comp_id
-            WHERE c.comp_type = '100002'
-        <if test="productName != null and productName != ''">
-            AND p.product_name LIKE '%' || #{productName} || '%'
-        </if>
-        <if test="categorySub != null and categorySub != ''">
-            AND get_datacode_name(p.category_sub) = #{categorySub}
-        </if>
-        <if test="compName != null and compName != ''">
-            AND c.comp_name LIKE '%' || #{compName} || '%'
-        </if>
-        <!-- 판매일자 범위 지정 -->
-        <if test="salesDatesFrom != null and salesDatesTo != null">
-            AND so.so_date BETWEEN #{salesDatesFrom} AND #{salesDatesTo}
-        </if>
-        <!-- 판매일자(시작일)만 지정된 경우 -->
-        <if test="salesDatesFrom != null and salesDatesTo == null">
-        <![CDATA[
-            AND so.so_date >= #{salesDatesFrom}
-        ]]>
-        </if>
-        <!-- 판매일자(종료일)만 지정된 경우 -->
-        <if test="salesDatesFrom == null and salesDatesTo != null">
-        <![CDATA[
-            AND so.so_date <= #{salesDatesTo}
-        ]]>
-        </if>
-            GROUP BY p.product_id, p.product_name, p.category_main, p.category_sub, c.comp_name, p.sell_price, p.product_spec, p.unit
+        SELECT p.product_id,
+               p.product_name,
+               get_datacode_name(p.category_main) as category_main,
+               get_datacode_name(p.category_sub) as category_sub,
+               c.comp_name,
+               p.sell_price,
+               SUM(sod.quantity) as quantity,
+               SUM(sod.quantity * sod.price) as total_price,
+               p.product_spec || get_datacode_name(p.unit) as product_spec
+        FROM   sales_orders so JOIN sales_orders_detail sod ON so.so_id = sod.so_id
+                               JOIN products p ON sod.product_id = p.product_id
+                               JOIN companys c ON so.comp_id = c.comp_id
+        WHERE  c.comp_type = '100002'
+          AND  so.status = '020001'
+    <if test="productName != null and productName != ''">
+          AND  p.product_name LIKE '%' || #{productName} || '%'
+    </if>
+    <choose>
+        <when test="categorySub == null or categorySub == ''">
+        </when>
+        <when test="categorySub.endsWith('전체')">
+            AND  p.category_sub LIKE SUBSTR(get_datacode_value(#{categorySub}), 1, 3) || '%'
+        </when>
+        <otherwise>
+            AND  p.category_sub = get_datacode_value(#{categorySub})
+        </otherwise>
+    </choose>
+    <if test="compName != null and compName != ''">
+          AND  c.comp_name LIKE '%' || #{compName} || '%'
+    </if>
+    <!-- 판매일자 범위 지정 -->
+    <if test="salesDatesFrom != null and salesDatesTo != null">
+          AND  TRUNC(so.so_date) BETWEEN #{salesDatesFrom} AND #{salesDatesTo}
+    </if>
+    <!-- 판매일자(시작일)만 지정된 경우 -->
+    <if test="salesDatesFrom != null and salesDatesTo == null">
+    <![CDATA[
+          AND TRUNC(so.so_date) >= #{salesDatesFrom}
+    ]]>
+    </if>
+    <!-- 판매일자(종료일)만 지정된 경우 -->
+    <if test="salesDatesFrom == null and salesDatesTo != null">
+    <![CDATA[
+          AND TRUNC(so.so_date) <= #{salesDatesTo}
+    ]]>
+    </if>
+        GROUP BY p.product_id, p.product_name, p.category_main, p.category_sub, c.comp_name, p.sell_price, p.product_spec, p.unit
         ORDER BY c.comp_name, p.product_id
     </select>
 </mapper>

--- a/server/src/main/resources/mapper/sales/sales-order-mapper.xml
+++ b/server/src/main/resources/mapper/sales/sales-order-mapper.xml
@@ -38,11 +38,14 @@
         	<if test="status != null and status != ''">
                 AND so.status = #{status}
             </if>
-            <if test="soDateFrom != null">
-	            AND so.so_date &gt;= #{soDateFrom}
+            <if test="soDateFrom != null and soDateTo != null">
+	            AND TRUNC(so.so_date) BETWEEN #{soDateFrom} AND #{soDateTo}
 	        </if>
-	        <if test="soDateTo != null">
-	            AND so.so_date &lt;= #{soDateTo}
+	        <if test="soDateFrom != null and soDateTo == null">
+	            AND TRUNC(so.so_date) &gt;= #{soDateFrom}
+	        </if>
+	        <if test="soDateFrom == null and soDateTo != null">
+	            AND TRUNC(so.so_date) &lt;= #{soDateTo}
 	        </if>
         </where>
         ORDER BY so.so_id DESC
@@ -131,4 +134,47 @@
             #{soId}
         )
     </insert>
+
+    <!-- 일일 정산 등록 -->
+    <insert id="insertDailyClosing" parameterType="SalesDailyClosingVO">
+        INSERT INTO branch_closing (
+            comp_id,
+            closing_date,
+            total_price
+        ) VALUES (
+            #{compId},
+            #{closingDate},
+            #{totalPrice}
+        )
+    </insert>
+
+    <!-- 일일 정산을 위한 일 매출 총액 조회 -->
+    <select id="selectDailySummary" parameterType="SalesDailyClosingVO" resultType="double">
+        SELECT
+            SUM(total_price) AS total_price
+        FROM
+            sales_orders
+        WHERE
+            TRUNC(so_date) = #{closingDate}
+            AND comp_id = #{compId}
+            AND status = '020001'
+    </select>
+
+    <!-- 일일 정산을 위한 결제방식별 매출 집계 조회 -->
+    <select id="selectDailySummaryByPaymentType" resultType="java.util.HashMap">
+        SELECT
+            COUNT(*) AS order_count,
+            SUM(total_price) AS total_amount,
+            SUM(CASE WHEN payment_type = '160001' THEN total_price ELSE 0 END) AS cash_amount,
+            SUM(CASE WHEN payment_type = '160002' THEN total_price ELSE 0 END) AS transfer_amount,
+            SUM(CASE WHEN payment_type = '160003' THEN total_price ELSE 0 END) AS card_amount
+        FROM
+            sales_orders
+        WHERE
+            TRUNC(so_date) = TO_DATE(#{date}, 'YYYY-MM-DD')
+            <if test="compId != null and compId != ''">
+                AND comp_id = #{compId}
+            </if>
+            AND status = '020001'
+    </select>
 </mapper>

--- a/server/src/main/resources/mapper/stock/branch-inventory-mapper.xml
+++ b/server/src/main/resources/mapper/stock/branch-inventory-mapper.xml
@@ -86,13 +86,20 @@
                  bs.comp_name,
                  p.safety_stock
         FROM     products p JOIN branch_stocks bs ON p.product_id = bs.product_id
-        WHERE    1=1
+        WHERE    p.status = '040001'
         <if test="productName != null and productName != ''">
                 AND p.product_name LIKE '%' || #{productName} || '%'
         </if>
-        <if test="categorySub != null and categorySub != ''">
-                AND get_datacode_name(p.category_sub) = #{categorySub}
-        </if>
+        <choose>
+                <when test="categorySub == null or categorySub == ''">
+                </when>
+                <when test="categorySub.endsWith('전체')">
+                AND  p.category_sub LIKE SUBSTR(get_datacode_value(#{categorySub}), 1, 3) || '%'
+                </when>
+                <otherwise>
+                 AND  p.category_sub = get_datacode_value(#{categorySub})
+                </otherwise>
+        </choose>
         <if test="vendorName != null and vendorName != ''">
                 AND p.vendor_name LIKE '%' || #{vendorName} || '%'
         </if>

--- a/server/src/main/resources/mapper/stock/head-inventory-mapper.xml
+++ b/server/src/main/resources/mapper/stock/head-inventory-mapper.xml
@@ -156,13 +156,20 @@
                NVL(SUM(ls.stock_quantity), 0) AS stock_quantity,
                p.safety_stock
         FROM   products p LEFT JOIN lot_stocks ls ON p.product_id = ls.product_id
-        WHERE  1=1
+        WHERE  p.status = '040001'
         <if test="productName != null and productName != ''">
           AND p.product_name LIKE '%' || #{productName} || '%'
         </if>
-        <if test="categorySub != null and categorySub != ''">
-          AND get_datacode_name(category_sub) = #{categorySub}
-        </if>
+        <choose>
+            <when test="categorySub == null or categorySub == ''">
+            </when>
+            <when test="categorySub.endsWith('전체')">
+          AND  p.category_sub LIKE SUBSTR(get_datacode_value(#{categorySub}), 1, 3) || '%'
+            </when>
+            <otherwise>
+          AND  p.category_sub = get_datacode_value(#{categorySub})
+            </otherwise>
+        </choose>
         <if test="vendorName != null and vendorName != ''">
           AND p.vendor_name LIKE '%' || #{vendorName} || '%'
         </if>


### PR DESCRIPTION
[공통 사항]
검색 폼 내에서 입력폼과 버튼 사이 간격 좁힘
비활성화 된 제품이 조회 안 되도록 변경

[본사 지점 재고]
규격과 공급사는 공통사항이라 위쪽으로 이동
안전재고에 따라 수량 상태가 구분되도록 색 구분
박스 -> 개
대분류로만 조회할 수 있도록 추가

[판매 이력 조회]
매출 이력은 초기 조회 시 기간(최근 일주일) 미리 지정
초기화 눌렀을 때 지점명이 초기화되면서 전체 지점의 판매 이력이 조회되는 오류 수정
지점명 검색 버튼은 막혀있지만, 직접 수정이 가능한 상태 수정
페이지 내의 폼 이름 '판매 이력 검색'으로 통일

[주문 조회]
주문 조회 -> 주문 조회 및 일일 마감(지점)
일일 마감 버튼 누르면, 모달에 오늘 카드/현금/이체 얼마인지 합계 보여주고 최종 정산 버튼 넣어주기. 정산 누르면 지점 정산 테이블에 날짜랑 금액 기록